### PR TITLE
Add 'compute' keyword to `rio_save` for delayed dask storing

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -824,6 +824,7 @@ class TestXRImage(unittest.TestCase):
             self.assertIsInstance(delay[0], da.Array)
             self.assertIsInstance(delay[1], xrimage.RIOFile)
             da.store(*delay)
+            delay[1].close()
 
     def test_gamma(self):
         """Test gamma correction."""

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -797,7 +797,6 @@ class TestXRImage(unittest.TestCase):
     def test_save_geotiff(self):
         import xarray as xr
         import dask.array as da
-        from dask.delayed import Delayed
         from trollimage import xrimage
 
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3) / 75., dims=[
@@ -821,8 +820,10 @@ class TestXRImage(unittest.TestCase):
         # dask delayed save
         with NamedTemporaryFile(suffix='.tif') as tmp:
             delay = img.save(tmp.name, compute=False)
-            self.assertIsInstance(delay, Delayed)
-            delay.compute()
+            self.assertIsInstance(delay, tuple)
+            self.assertIsInstance(delay[0], da.Array)
+            self.assertIsInstance(delay[1], xrimage.RIOFile)
+            da.store(*delay)
 
     def test_gamma(self):
         """Test gamma correction."""

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -767,6 +767,7 @@ class TestXRImage(unittest.TestCase):
     def test_save(self):
         import xarray as xr
         import dask.array as da
+        from dask.delayed import Delayed
         from trollimage import xrimage
 
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3) / 75., dims=[
@@ -786,6 +787,12 @@ class TestXRImage(unittest.TestCase):
         img = xrimage.XRImage(data)
         with NamedTemporaryFile(suffix='.png') as tmp:
             img.save(tmp.name)
+
+        # dask delayed save
+        with NamedTemporaryFile(suffix='.png') as tmp:
+            delay = img.save(tmp.name, compute=False)
+            self.assertIsInstance(delay, Delayed)
+            delay.compute()
 
     def test_gamma(self):
         """Test gamma correction."""

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -195,13 +195,31 @@ class XRImage(object):
              format_kw=None):
         """Save the image to the given *filename*.
 
-        For some formats like jpg and png, the work is delegated to
-        :meth:`pil_save`, which doesn't support the *compression* option.
+        Args:
+            filename (str): Output filename
+            fformat (str): File format of output file (optional). Can be
+                           one of many image formats supported by the
+                           `rasterio` or `PIL` libraries ('jpg', 'png',
+                           'tif'). By default this is deteremined by the
+                           extension of the provided filename.
+            fill_value (float): Replace invalid data values with this value
+                                and do not produce an Alpha band. Default
+                                behavior is to create an alpha band.
+            compute (bool): If True (default) write the data to the file
+                            immediately. If False the return value is either
+                            a `dask.Delayed` object or a tuple of
+                            ``(source, target)`` to be passed to
+                            `dask.array.store`.
+            format_kw (dict): Additional format options to pass to `rasterio`
+                              or `PIL` saving methods.
 
-        The `compute` keyword argument controls dask delayed operations. If
-        `True` (default) all operations are computed immediately. If `False`
-        then a Dask Delayed object is returned and can be computed later with
-        `delayed.compute()`.
+        Returns:
+            Either `None` if `compute` is True or a `dask.Delayed` object or
+            ``(source, target)`` pair to be passed to `dask.array.store`.
+            If compute is False the return value depends on format and how
+            the image backend is used. If ``(source, target)`` is provided
+            then target is an open file-like object that must be closed by
+            the caller.
 
         """
         fformat = fformat or os.path.splitext(filename)[1][1:4]

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -113,6 +113,12 @@ class RIOFile(object):
         """Exit method."""
         self.close()
 
+    def __del__(self):
+        try:
+            self.close()
+        except (IOError, OSError):
+            pass
+
     @property
     def colorinterp(self):
         """Return the color interpretation of the image."""


### PR DESCRIPTION
Adds 'compute' keyword so SatPy or users can request a dask Delayed object instead of saving the image immediately. This should allow users to share any computations between multiple XRImages.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

The "fully" part of the "fully documented" above is a strong word.