### PR TITLE
Add setup.py extra for 'geotiff' so 'rasterio' is installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,6 @@ setup(name="trollimage",
       packages=['trollimage'],
       zip_safe=False,
       install_requires=['numpy >=1.6', 'pillow', 'six'],
+      extras_require={'geotiff': ['rasterio']},
       test_suite='trollimage.tests.suite',
       )


### PR DESCRIPTION
Small fix to setup.py so there is now a 'geotiff' extra so 'rasterio' can get installed with `pip install trollimage[geotiff]`.

 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)
