### PR TITLE
Add ability to rename dimensions on 2D arrays passed to XRImage

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -754,6 +754,21 @@ class TestXRImage(unittest.TestCase):
         img = xrimage.XRImage(data)
         self.assertEqual(img.mode, 'L')
 
+        data = xr.DataArray([[0, 0.5, 0.5], [0.5, 0.25, 0.25]])
+        img = xrimage.XRImage(data)
+        self.assertEqual(img.mode, 'L')
+        self.assertTupleEqual(img.data.dims, ('bands', 'y', 'x'))
+
+        data = xr.DataArray([[0, 0.5, 0.5], [0.5, 0.25, 0.25]], dims=['x', 'y_2'])
+        img = xrimage.XRImage(data)
+        self.assertEqual(img.mode, 'L')
+        self.assertTupleEqual(img.data.dims, ('bands', 'x', 'y'))
+
+        data = xr.DataArray([[0, 0.5, 0.5], [0.5, 0.25, 0.25]], dims=['x_2', 'y'])
+        img = xrimage.XRImage(data)
+        self.assertEqual(img.mode, 'L')
+        self.assertTupleEqual(img.data.dims, ('bands', 'x', 'y'))
+
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3), dims=[
                             'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)


### PR DESCRIPTION
Adds functionality to XRImage so dimensions can be renamed to what it expects: `('bands', 'y', 'x')`. Previously a 2D array with no x/y dimensions was not allowed.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)