### PR TITLE
Update travis to use ci-helpers and add appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,12 @@ env:
         - CONDA_CHANNELS='conda-forge'
 install:
 # Get rasterio 1.0
-- conda install -c conda-forge/label/dev rasterio
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda.sh
+    - conda install -c conda-forge/label/dev rasterio
 script: coverage run --source=trollimage setup.py test
 after_success:
-- if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then coveralls; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then coveralls; fi
 deploy:
   provider: pypi
   user: dhoese

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,33 @@
 language: python
-addons:
-  apt:
-    packages:
-    - gdal-bin
-    - libgdal-dev
 python:
 - '2.7'
-- '3.5'
 - '3.6'
+env:
+    global:
+        # Set defaults to avoid repeating in most cases
+        - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
+        - NUMPY_VERSION=stable
+        - MAIN_CMD='python setup.py'
+        - CONDA_DEPENDENCIES='pillow gdal xarray dask toolz coverage coveralls codecov'
+        - SETUP_XVFB=False
+        - EVENT_TYPE='push pull_request'
+        - SETUP_CMD='test'
+        - CONDA_CHANNELS='conda-forge'
 install:
-- pip install .
-- pip install xarray dask toolz rasterio==1.0a12
-- pip install coveralls
+# Get rasterio 1.0
+- conda install -c conda-forge/label/dev rasterio
 script: coverage run --source=trollimage setup.py test
-after_success: coveralls
+after_success:
+- if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then coveralls; fi
 deploy:
   provider: pypi
-  user: Martin.Raspaud
+  user: dhoese
   password:
-    secure: RuQzdaLTY4sryIzG8Hz1KWEsyYRxrLvbyfm7DurXDPcj2vsujRwJicNwBrJajIBkzZWwdmWE8db55BPWZwCsJtVUbE53vc742wSAcci2zzCgizSb/jjlDkwk1CE/PoMl4t3JsuIU6bklgw1Y1d4Xn4+BeZe8Blol5PD/FUovxfo=
+    secure: "Cpo7kPgjbyWKNRjnzWDggxo5dqG8KdtcrBxYWwBpkkhgly/ngN9EkjIdscrwmp8sCqfjTd0RGyR811k6dzU7kKJVbc6V309+4mG8O0w4IvfHCn+NaHymAMrHleRIqyxbo5kvrBZoX+eB7YWOUppF6ofeohbrNWWgMQv+/d+Mufs="
   on:
-    tags: true
     repo: pytroll/trollimage
-sudo: false
+    tags: true
+    python: 3.6
+    distributions: sdist bdist_wheel
 notifications:
   slack: pytroll:96mNSYSI1dBjGyzVXkBT6qFt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+environment:
+  global:
+    PYTHON: "C:\\conda"
+    MINICONDA_VERSION: "latest"
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+    CONDA_DEPENDENCIES: "pillow gdal xarray dask toolz coverage coveralls codecov"
+    CONDA_CHANNELS: "conda-forge"
+
+  matrix:
+    - PYTHON: "C:\\Python27_64"
+      PYTHON_VERSION: "2.7"
+      PYTHON_ARCH: "64"
+      NUMPY_VERSION: "stable"
+
+    - PYTHON: "C:\\Python36_64"
+      PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      NUMPY_VERSION: "stable"
+
+install:
+    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+    - "powershell ci-helpers/appveyor/install-miniconda.ps1"
+    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+    - "activate test"
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  - "%CMD_IN_ENV% python setup.py test"
+
+after_test:
+  # If tests are successful, create a whl package for the project.
+  - "%CMD_IN_ENV% python setup.py bdist_wheel bdist_wininst"
+  - ps: "ls dist"
+
+artifacts:
+  # Archive the generated wheel package in the ci.appveyor.com build report.
+  - path: dist\*
+
+#on_success:
+#  - TODO: upload the content of dist/*.whl to a public wheelhouse
+#

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -349,7 +349,8 @@ class TestRegularImage(unittest.TestCase):
         # create an unusable directory for permission error checking
 
         self.tempdir = tempfile.mkdtemp()
-        os.chmod(self.tempdir, 0000)
+        # read-only
+        os.chmod(self.tempdir, 0o444)
 
     def test_shape(self):
         """Shape of an image.
@@ -673,6 +674,7 @@ class TestRegularImage(unittest.TestCase):
         """Clean up the mess.
         """
         import os
+        os.chmod(self.tempdir, 0o777)
         os.rmdir(self.tempdir)
 
 

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -23,8 +23,12 @@
 # along with mpop.  If not, see <http://www.gnu.org/licenses/>.
 """Module for testing the imageo.image module.
 """
+import os
+import sys
+import stat
 import random
 import unittest
+import tempfile
 from tempfile import NamedTemporaryFile
 
 import numpy as np
@@ -324,8 +328,6 @@ class TestRegularImage(unittest.TestCase):
     def setUp(self):
         """Setup the test.
         """
-        import os
-        import tempfile
         one_channel = np.random.rand(random.randint(1, 10),
                                      random.randint(1, 10))
         self.rand_img = image.Image(channels=[one_channel] * 3,
@@ -350,7 +352,10 @@ class TestRegularImage(unittest.TestCase):
 
         self.tempdir = tempfile.mkdtemp()
         # read-only
-        os.chmod(self.tempdir, 0o444)
+        if 'win' in sys.platform:
+            os.chmod(self.tempdir, stat.S_IREAD)
+        else:
+            os.chmod(self.tempdir, 0o444)
 
     def test_shape(self):
         """Shape of an image.
@@ -673,8 +678,11 @@ class TestRegularImage(unittest.TestCase):
     def tearDown(self):
         """Clean up the mess.
         """
-        import os
-        os.chmod(self.tempdir, 0o777)
+        # read-only
+        if 'win' in sys.platform:
+            os.chmod(self.tempdir, stat.S_IWRITE)
+        else:
+            os.chmod(self.tempdir, 0o777)
         os.rmdir(self.tempdir)
 
 


### PR DESCRIPTION
Adds appveyor tests and switches travis to use ci-helpers and conda.

 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)
