### PR TITLE
Fix writing 'L' mode images with extra dimensions

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -795,6 +795,18 @@ class TestXRImage(unittest.TestCase):
         with NamedTemporaryFile(suffix='.png') as tmp:
             img.save(tmp.name)
 
+        # Single band image
+        data = xr.DataArray(np.arange(75).reshape(15, 5, 1) / 75., dims=[
+                            'y', 'x', 'bands'], coords={'bands': ['L']})
+        # Single band image to JPEG
+        img = xrimage.XRImage(data)
+        with NamedTemporaryFile(suffix='.jpg') as tmp:
+            img.save(tmp.name, fill_value=0)
+        # As PNG that support alpha channel
+        img = xrimage.XRImage(data)
+        with NamedTemporaryFile(suffix='.png') as tmp:
+            img.save(tmp.name)
+
         data = xr.DataArray(da.from_array(np.arange(75).reshape(5, 5, 3) / 75.,
                                           chunks=5),
                             dims=['y', 'x', 'bands'],
@@ -802,6 +814,7 @@ class TestXRImage(unittest.TestCase):
         img = xrimage.XRImage(data)
         with NamedTemporaryFile(suffix='.png') as tmp:
             img.save(tmp.name)
+
         data = data.where(data > (10 / 75.0))
         img = xrimage.XRImage(data)
         with NamedTemporaryFile(suffix='.png') as tmp:

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -430,9 +430,8 @@ class XRImage(object):
     def pil_image(self, fill_value=None):
         """Return a PIL image from the current image."""
         channels, mode = self.finalize(fill_value)
-        return PILImage.fromarray(
-            np.asanyarray(channels.transpose('y', 'x', 'bands').values),
-            mode)
+        res = np.asanyarray(channels.transpose('y', 'x', 'bands').values)
+        return PILImage.fromarray(np.squeeze(res), mode)
 
     def xrify_tuples(self, tup):
         """Make xarray.DataArray from tuple."""


### PR DESCRIPTION
 - [x] Closes #23
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)

This fixes a minor oversight that prevented saving 'L' mode images when `fill_value` keyword argument was used.