### PR TITLE
Change default value of `tags` kwarg to `None` in `rio_save()`

### DIFF
--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -260,13 +260,16 @@ class XRImage(object):
                                  compute=compute, **format_kwargs)
 
     def rio_save(self, filename, fformat=None, fill_value=None,
-                 dtype=np.uint8, compute=True, tags={}, **format_kwargs):
+                 dtype=np.uint8, compute=True, tags=None, **format_kwargs):
         """Save the image using rasterio."""
         fformat = fformat or os.path.splitext(filename)[1][1:4]
         drivers = {'jpg': 'JPEG',
                    'png': 'PNG',
                    'tif': 'GTiff'}
         driver = drivers.get(fformat, fformat)
+
+        if tags is None:
+            tags = {}
 
         data, mode = self.finalize(fill_value, dtype=dtype)
         data = data.transpose('bands', 'y', 'x')


### PR DESCRIPTION
The current `master` branch has the default value of `tags` kwarg as an empty dictionary in `rio_save()`. When used with a program, like trollflow, that uses configuration files and no extra tags are given, it's logical to set `tags=None` in the config.

This PR changes the default value to `None` and adjusts the value to an empty dict if this is the case when called.

 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
