### PR TITLE
Fix crude stretch not calculating min/max per-band

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -897,19 +897,24 @@ class TestXRImage(unittest.TestCase):
         import xarray as xr
         from trollimage import xrimage
 
-        arr = np.arange(75).reshape(5, 5, 3) / 74.
+        arr = np.arange(75).reshape(5, 5, 3)
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
         img.crude_stretch()
-        self.assertTrue(np.allclose(img.data.values, arr))
+        red = img.data.sel(bands='R')
+        green = img.data.sel(bands='G')
+        blue = img.data.sel(bands='B')
+        np.testing.assert_allclose(red, arr[:, :, 0] / 72.)
+        np.testing.assert_allclose(green, (arr[:, :, 1] - 1.) / (73. - 1.))
+        np.testing.assert_allclose(blue, (arr[:, :, 2] - 2.) / (74. - 2.))
 
         arr = np.arange(75).reshape(5, 5, 3).astype(float)
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
         img.crude_stretch(0, 74)
-        self.assertTrue(np.allclose(img.data.values, arr / 74.))
+        np.testing.assert_allclose(img.data.values, arr / 74.)
 
     def test_invert(self):
         """Check inversion of the image."""

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -635,9 +635,11 @@ class XRImage(object):
         the [0,1] range.
         """
         if min_stretch is None:
-            min_stretch = self.data.min()
+            non_band_dims = tuple(x for x in self.data.dims if x != 'bands')
+            min_stretch = self.data.min(dim=non_band_dims)
         if max_stretch is None:
-            max_stretch = self.data.max()
+            non_band_dims = tuple(x for x in self.data.dims if x != 'bands')
+            max_stretch = self.data.max(dim=non_band_dims)
 
         if isinstance(min_stretch, (list, tuple)):
             min_stretch = self.xrify_tuples(min_stretch)


### PR DESCRIPTION
Doing `data_arr.min()` computes the min/max across all bands together. We want this separated out so we end up with a minimum value for each band separately.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
