### PR TITLE
Fix XRImage's finalize method when input data are integers

### DIFF
--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -512,14 +512,14 @@ class XRImage(object):
                 # preserve integer data type
                 final_data = final_data.clip(np.iinfo(dtype).min, np.iinfo(dtype).max)
             else:
-                # scale float data (assumed to be 0 to 1) to integer space
-                final_data = final_data.clip(0, 1) * np.iinfo(dtype).max
+                # scale float data (assumed to be 0 to 1) to full integer space
+                dinfo = np.iinfo(dtype)
+                final_data = final_data.clip(0, 1) * (dinfo.max - dinfo.min) + dinfo.min
             final_data = final_data.round()
         final_data = self.fill_or_alpha(final_data, fill_value)
         final_data = final_data.astype(dtype)
 
         final_data.attrs = self.data.attrs
-
         return final_data, ''.join(final_data['bands'].values)
 
     def pil_image(self, fill_value=None):

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -506,13 +506,17 @@ class XRImage(object):
                            "setting fill_value to 0")
             fill_value = 0
 
-        final_data = self.fill_or_alpha(self.data, fill_value)
-
+        final_data = self.data
         if np.issubdtype(dtype, np.integer):
-            final_data = final_data.clip(0, 1) * np.iinfo(dtype).max
-            final_data = final_data.round().astype(dtype)
-        else:
-            final_data = final_data.astype(dtype)
+            if np.issubdtype(final_data, np.integer):
+                # preserve integer data type
+                final_data = final_data.clip(np.iinfo(dtype).min, np.iinfo(dtype).max)
+            else:
+                # scale float data (assumed to be 0 to 1) to integer space
+                final_data = final_data.clip(0, 1) * np.iinfo(dtype).max
+            final_data = final_data.round()
+        final_data = self.fill_or_alpha(final_data, fill_value)
+        final_data = final_data.astype(dtype)
 
         final_data.attrs = self.data.attrs
 


### PR DESCRIPTION
This PR fixes two main issues:

1. Saving input data that were represented as integers always clipped the data to 0-1 and then scaled the data to fit the output data type. This made it impossible to save integer data in XRImage without first enhancing it.
2. Signed output data types were not properly being used and data was only filling the upper half of the integer space.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
