### PR TITLE
Fix xrimage alpha creation in finalize

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -864,6 +864,7 @@ class TestXRImage(unittest.TestCase):
             np.testing.assert_allclose(file_data[0], exp[:, :, 0])
             np.testing.assert_allclose(file_data[1], exp[:, :, 1])
             np.testing.assert_allclose(file_data[2], exp[:, :, 2])
+            np.testing.assert_allclose(file_data[3], 255)  # completely opaque
 
         data = xr.DataArray(da.from_array(np.arange(75.).reshape(5, 5, 3) / 75., chunks=5),
                             dims=['y', 'x', 'bands'],
@@ -879,6 +880,7 @@ class TestXRImage(unittest.TestCase):
             np.testing.assert_allclose(file_data[0], exp[:, :, 0])
             np.testing.assert_allclose(file_data[1], exp[:, :, 1])
             np.testing.assert_allclose(file_data[2], exp[:, :, 2])
+            np.testing.assert_allclose(file_data[3], 255)  # completely opaque
 
         # with NaNs
         data = data.where(data > 10. / 75.)
@@ -894,6 +896,9 @@ class TestXRImage(unittest.TestCase):
             np.testing.assert_allclose(file_data[0], exp[:, :, 0])
             np.testing.assert_allclose(file_data[1], exp[:, :, 1])
             np.testing.assert_allclose(file_data[2], exp[:, :, 2])
+            is_null = (exp == 0).all(axis=2)
+            np.testing.assert_allclose(file_data[3][~is_null], 255)  # completely opaque
+            np.testing.assert_allclose(file_data[3][is_null], 0)  # completely transparent
 
         # with fill value
         with NamedTemporaryFile(suffix='.tif') as tmp:

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -377,16 +377,27 @@ class XRImage(object):
 
         return meta
 
-    def fill_or_alpha(self, data, fill_value=None):
+    def fill_or_alpha(self, data, fill_value=None, dtype=None):
         """Fill the data with fill_value or create an alpha channel."""
+        if dtype is None:
+            dtype = data.dtype.type
         if fill_value is None and not self.mode.endswith("A"):
             not_alpha = [b for b in data.coords['bands'].values if b != 'A']
             # if any of the bands are valid, we don't want transparency
             null_mask = data.sel(bands=not_alpha).notnull().any(dim='bands')
             null_mask = null_mask.expand_dims('bands')
             null_mask['bands'] = ['A']
-            data = xr.concat([data, null_mask.astype(data.dtype)], dim="bands")
+            null_mask = null_mask.astype(dtype)
+            # if we are creating an integer field, then alpha needs to be max-int
+            # otherwise for floats we want 0 to 1
+            if np.issubdtype(dtype, np.integer):
+                dinfo = np.iinfo(dtype)
+                null_mask = null_mask * (dinfo.max - dinfo.min) + dinfo.min
+            data = xr.concat([data, null_mask], dim="bands")
         elif fill_value is not None:
+            # convert fill_value to the current arrays data type to avoid
+            # implicit data array type conversion
+            fill_value = dtype(fill_value)
             data = data.fillna(fill_value)
         return data
 
@@ -506,15 +517,7 @@ class XRImage(object):
                            "setting fill_value to 0")
             fill_value = 0
 
-        # convert fill_value to the current arrays data type to avoid
-        # implicit data array type conversion
-        notnull_mask = None
-        if fill_value is not None:
-            fill_value = self.data.dtype.type(fill_value)
-            # hold on to fill mask for later use
-            notnull_mask = self.data.notnull()
-        final_data = self.fill_or_alpha(self.data, fill_value)
-
+        final_data = self.data
         if np.issubdtype(dtype, np.integer):
             if np.issubdtype(final_data, np.integer):
                 # preserve integer data type
@@ -524,10 +527,7 @@ class XRImage(object):
                 dinfo = np.iinfo(dtype)
                 final_data = final_data.clip(0, 1) * (dinfo.max - dinfo.min) + dinfo.min
             final_data = final_data.round()
-        # if we used a fill_value it would have been scaled to the data type
-        # we need to get the desired fill_value back
-        if fill_value is not None:
-            final_data = final_data.where(notnull_mask, fill_value)
+        final_data = self.fill_or_alpha(final_data, fill_value, dtype=dtype)
         final_data = final_data.astype(dtype)
 
         final_data.attrs = self.data.attrs


### PR DESCRIPTION
This is to fix the huge bug in trollimage 1.6.1. Right now it is producing seemingly completely transparent images. The solution that works here is not the prettiest but it should work for the supported cases. There is another possibility but I'm not sure it is any better. Here are the two cases that are in conflict and the preferred series of operations to complete these tasks:

1. Add alpha band
a. Create alpha band from "null" values
b. Scale data to output data type including scale the alpha band from 0-1 to dtype_min to dtype_max
c. Cast to data type

2. Fill NA values with `fill_value`
a. Scale data to output data type
b. Fill "null" values with fill_value (after casting it to output data type)
c. Cast to data type

If you change these operations around to support only one of these cases it results in either an all `1` alpha band or a `fill_value` that does not represent the original user provided one.

Best long term solution would be to modify `fill_or_alpha` to accept a dtype kwarg and absorb some of this functionality (maybe scaling to the dtype). The `fill_or_alpha` is currently used by the `convert` method and I'm not sure if any users have started using it (I doubt it), but it is a public method.

@mraspaud Thoughts?

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)

