### PR TITLE
Add support for saving gcps

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -851,7 +851,7 @@ class TestXRImage(unittest.TestCase):
         from trollimage import xrimage
         import rasterio as rio
 
-	# numpy array image - scale to 0 to 1 first
+        # numpy array image - scale to 0 to 1 first
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3) / 75.,
                             dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -850,8 +850,9 @@ class TestXRImage(unittest.TestCase):
         import dask.array as da
         from trollimage import xrimage
 
-        data = xr.DataArray(np.arange(75).reshape(5, 5, 3) / 75., dims=[
-            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+        data = xr.DataArray(np.arange(75).reshape(5, 5, 3) / 75.,
+                            dims=['y', 'x', 'bands'],
+                            coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
         with NamedTemporaryFile(suffix='.tif') as tmp:
             img.save(tmp.name)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -227,6 +227,9 @@ class XRImage(object):
                            `rasterio` or `PIL` libraries ('jpg', 'png',
                            'tif'). By default this is determined by the
                            extension of the provided filename.
+                           If the format allows, geographical information will
+                           be saved to the ouput file, in the form of grid
+                           mapping or ground control points.
             fill_value (float): Replace invalid data values with this value
                                 and do not produce an Alpha band. Default
                                 behavior is to create an alpha band.

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -308,7 +308,6 @@ class XRImage(object):
                 except KeyError:
                     logger.info("Couldn't create geotransform")
 
-
             if "start_time" in data.attrs:
                 stime = data.attrs['start_time']
                 stime_str = stime.strftime("%Y:%m:%d %H:%M:%S")

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -304,7 +304,8 @@ class XRImage(object):
                 logger.info("Couldn't create geotransform")
             except AttributeError:
                 try:
-                    gcps, crs = data.attrs['area'].lons.attrs['gcps']
+                    gcps = data.attrs['area'].lons.attrs['gcps']
+                    crs = data.attrs['area'].lons.attrs['crs']
                 except KeyError:
                     logger.info("Couldn't create geotransform")
 


### PR DESCRIPTION
This PR adds the possibility to save Ground Control Points (GCP) to rasterio-supported formats. For this to work, the GCPs need to be stored in the attrs of the longitude array accompanying the main dataset.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
