### PR TITLE
Fix casting and scaling float arrays in finalize

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -977,7 +977,7 @@ class TestXRImage(unittest.TestCase):
         alpha = alpha.where(data.notnull().all(dim='bands'), 0)
         alpha['bands'] = 'A'
         # make a float version of a uint8 RGBA
-        rgb_data = xr.concat((data, alpha), dim='bands') * 255.
+        rgb_data = xr.concat((data, alpha), dim='bands')
         img = xrimage.XRImage(rgb_data)
         with NamedTemporaryFile(suffix='.tif') as tmp:
             img.save(tmp.name)
@@ -986,7 +986,7 @@ class TestXRImage(unittest.TestCase):
             self.assertEqual(file_data.shape, (4, 5, 5))  # alpha band already existed
             exp = np.arange(75.).reshape(5, 5, 3) / 75.
             exp[exp <= 10. / 75.] = 0  # numpy converts NaNs to 0s
-            exp = (exp * 255.).astype(np.uint8)
+            exp = (exp * 255.).round()
             np.testing.assert_allclose(file_data[0], exp[:, :, 0])
             np.testing.assert_allclose(file_data[1], exp[:, :, 1])
             np.testing.assert_allclose(file_data[2], exp[:, :, 2])

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -575,8 +575,8 @@ class XRImage(object):
                 final_data = final_data.where(final_data != ifill, fill_value)
             else:
                 final_data = final_data.fillna(fill_value)
-            final_data = final_data.astype(dtype)
 
+        final_data = final_data.astype(dtype)
         final_data.attrs = self.data.attrs
         return final_data, ''.join(final_data['bands'].values)
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -539,10 +539,16 @@ class XRImage(object):
         return self.finalize(fill_value, dtype)
 
     def finalize(self, fill_value=None, dtype=np.uint8):
-        """Finalize the image.
+        """Finalize the image to be written to an output file.
 
-        This sets the channels in unsigned 8bit format ([0,255] range)
-        (if the *dtype* doesn't say otherwise).
+        This adds an alpha band or fills data with a fill_value (if specified).
+        It also scales float data to the output range of the data type (0-255
+        for uint8, default). For integer input data this method assumes the
+        data is already scaled to the proper desired range. It will still fill
+        in invalid values and add an alpha band if needed. Integer input
+        data's fill value is determined by a special ``_FillValue`` attribute
+        in the ``DataArray`` ``.attrs`` dictionary.
+
         """
         if self.mode == "P":
             return self.convert("RGB").finalize(fill_value=fill_value, dtype=dtype)
@@ -562,19 +568,19 @@ class XRImage(object):
             alpha = self._create_alpha(final_data, fill_value=ifill)
             final_data = self._scale_to_dtype(final_data, dtype).astype(dtype)
             final_data = self._add_alpha(final_data, alpha=alpha)
-        elif fill_value is not None:
-            # cast fill value to output type so we don't change data type
-            fill_value = dtype(fill_value)
+        else:
             # scale float data to the proper dtype
             # this method doesn't cast yet so that we can keep track of NULL values
             final_data = self._scale_to_dtype(final_data, dtype)
             # Add fill_value after all other calculations have been done to
             # make sure it is not scaled for the data type
-            if ifill is not None:
+            if ifill is not None and fill_value is not None:
+                # cast fill value to output type so we don't change data type
+                fill_value = dtype(fill_value)
                 # integer fields have special fill values
-                final_data = final_data.where(final_data != ifill, fill_value)
-            else:
-                final_data = final_data.fillna(fill_value)
+                final_data = final_data.where(final_data != ifill, dtype(fill_value))
+            elif fill_value is not None:
+                final_data = final_data.fillna(dtype(fill_value))
 
         final_data = final_data.astype(dtype)
         final_data.attrs = self.data.attrs


### PR DESCRIPTION
Yet another bug found. If you use finalize on an RGBA array represented by floats it wasn't casting it to the output data type which was causing an error by rasterio. Additionally, it wasn't being scaled because it already had an alpha channel.

This should all be fixed now so all float input gets scaled to the output data range regardless of mode and is assumed to be between 0 and 1. All integer input data is left as is and is assumed to be the expected values. Any integer values that don't fit in the output data type are clipped. I've tried adding all this information to the docstring for finalize as well.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
