### PR TITLE
Refactor XRImage pil_save to be serializable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ env:
         - CONDA_CHANNEL_PRIORITY=True
 
 install:
-# Get rasterio 1.0
     - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-    - conda install -c conda-forge/label/dev rasterio
 script: coverage run --source=trollimage setup.py test
 after_success:
     - if [[ $PYTHON_VERSION == 3.6 ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='pillow gdal xarray dask toolz mock coverage coveralls codecov'
+        - CONDA_DEPENDENCIES='pillow gdal xarray dask toolz mock coverage coveralls codecov rasterio'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='conda-forge'
+        - CONDA_CHANNEL_PRIORITY=True
+
 install:
 # Get rasterio 1.0
     - git clone --depth 1 git://github.com/astropy/ci-helpers.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,9 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "pillow gdal xarray dask toolz mock coverage coveralls codecov"
+    CONDA_DEPENDENCIES: "pillow gdal xarray dask toolz mock coverage coveralls codecov rasterio"
     CONDA_CHANNELS: "conda-forge"
+    CONDA_CHANNEL_PRIORITY: "True"
 
   matrix:
     - PYTHON: "C:\\Python27_64"


### PR DESCRIPTION
I am playing around with using satpy on a cluster system, but have run in to some weird errors. I am able to create a PNG/JPEG image but only one. After the first one, when I save the second image I get a serialization error:

```
  File "/home/davidh/miniconda3/envs/pangeo/lib/python3.6/site-packages/distributed/protocol/core.py", line 53, in dumps
    for key, value in data.items()
  File "/home/davidh/miniconda3/envs/pangeo/lib/python3.6/site-packages/distributed/protocol/core.py", line 54, in <dictcomp>
    if type(value) is Serialize}
  File "/home/davidh/miniconda3/envs/pangeo/lib/python3.6/site-packages/distributed/protocol/serialize.py", line 157, in serialize
    raise TypeError(msg, str(x)[:10000])
TypeError: ('Could not serialize object of type tuple.', "(<function XRImage.pil_save.<locals>._create_save_image at 0x2aff94275268>, 0, '/odyssey/isis/tmp/davidh/true_color_20190201_180022.jpg', 'jpeg', (<class 'dict'>, [['config_files', ['/home/davidh/miniconda3/envs/pangeo/lib/python3.6/site-packages/satpy/etc/writers/simple_image.yaml']]]))")
```

I think this is due to the internal function that is being delayed and used. I think dask/pickle/cloudpickle is able to serialize the first version of the function but after that the function needs to be serialized again but it matches something that has already been serialized. This PR reorganizes how the delayed's are used. I still have to test this on the cluster and on my local system but preliminary tests seem to show it working.

If this works then I will likely need to make other PRs for the enhancement functions that use internal functions and swap them out for global functions or staticmethods on the XRImage.

 - [ ] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
