### PR TITLE
Add support for adding overviews to rasterio-managed files

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1223,7 +1223,7 @@ class TestXRImage(unittest.TestCase):
         with NamedTemporaryFile(suffix='.tif') as tmp:
             img.save(tmp.name, overviews=[2, 4])
             with rio.open(tmp.name) as f:
-                self.assertListEqual(f.overviews(1), [2, 2])
+                self.assertEqual(len(f.overviews(1)))
 
     def test_gamma(self):
         """Test gamma correction."""

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1187,7 +1187,7 @@ class TestXRImage(unittest.TestCase):
 
     @unittest.skipIf(sys.platform.startswith('win'), "'NamedTemporaryFile' not supported on Windows")
     def test_save_jp2_int(self):
-        """Test saving geotiffs when input data is int."""
+        """Test saving jp2000 when input data is int."""
         import xarray as xr
         from trollimage import xrimage
         import rasterio as rio
@@ -1207,6 +1207,23 @@ class TestXRImage(unittest.TestCase):
             np.testing.assert_allclose(file_data[1], exp[:, :, 1])
             np.testing.assert_allclose(file_data[2], exp[:, :, 2])
             np.testing.assert_allclose(file_data[3], 255)
+
+    @unittest.skipIf(sys.platform.startswith('win'), "'NamedTemporaryFile' not supported on Windows")
+    def test_save_overviews(self):
+        """Test saving geotiffs with overviews."""
+        import xarray as xr
+        from trollimage import xrimage
+        import rasterio as rio
+
+        # numpy array image
+        data = xr.DataArray(np.arange(75).reshape(5, 5, 3), dims=[
+            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+        img = xrimage.XRImage(data)
+        self.assertTrue(np.issubdtype(img.data.dtype, np.integer))
+        with NamedTemporaryFile(suffix='.tif') as tmp:
+            img.save(tmp.name, overviews=[2, 4])
+            with rio.open(tmp.name) as f:
+                self.assertListEqual(f.overviews(1), [2, 2])
 
     def test_gamma(self):
         """Test gamma correction."""

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1223,7 +1223,7 @@ class TestXRImage(unittest.TestCase):
         with NamedTemporaryFile(suffix='.tif') as tmp:
             img.save(tmp.name, overviews=[2, 4])
             with rio.open(tmp.name) as f:
-                self.assertEqual(len(f.overviews(1)))
+                self.assertEqual(len(f.overviews(1)), 2)
 
     def test_gamma(self):
         """Test gamma correction."""

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -104,6 +104,7 @@ class RIOFile(object):
     def close(self):
         if not self._closed:
             if self.overviews:
+                logger.debug('Building overviews %s', str(self.overviews))
                 self.rfile.build_overviews(self.overviews)
             self.rfile.close()
             self._closed = True

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -70,6 +70,7 @@ class RIOFile(object):
         self.kwargs = kwargs
         self.rfile = None
         self._closed = True
+        self.overviews = kwargs.pop('overviews', None)
 
     def __setitem__(self, key, item):
         """Put the data chunk in the image."""
@@ -102,6 +103,8 @@ class RIOFile(object):
 
     def close(self):
         if not self._closed:
+            if self.overviews:
+                self.rfile.build_overviews(self.overviews)
             self.rfile.close()
             self._closed = True
 
@@ -273,7 +276,13 @@ class XRImage(object):
                  dtype=np.uint8, compute=True, tags=None,
                  keep_palette=False, cmap=None,
                  **format_kwargs):
-        """Save the image using rasterio."""
+        """Save the image using rasterio.
+
+        Overviews can be added to the file using the `overviews` kwarg, eg::
+
+          img.rio_save('myfile.tif', overviews=[2, 4, 8, 16])
+
+        """
         fformat = fformat or os.path.splitext(filename)[1][1:4]
         drivers = {'jpg': 'JPEG',
                    'png': 'PNG',


### PR DESCRIPTION
This PR adds the possibility to save overviews to a newly created file (rasterio only feature). 

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
