### PR TITLE
Implement blend method for XRImage class

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1785,14 +1785,14 @@ class TestXRImage(unittest.TestCase):
         import xarray as xr
         from trollimage import xrimage
 
-        core1 = np.arange(75).reshape(5, 5, 3) / 75
+        core1 = np.arange(75).reshape(5, 5, 3) / 75.0
         alpha1 = np.linspace(0, 1, 25).reshape(5, 5, 1)
         arr1 = np.concatenate([core1, alpha1], 2)
         data1 = xr.DataArray(arr1, dims=['y', 'x', 'bands'],
                              coords={'bands': ['R', 'G', 'B', 'A']})
         img1 = xrimage.XRImage(data1)
 
-        core2 = np.arange(75, 0, -1).reshape(5, 5, 3) / 75
+        core2 = np.arange(75, 0, -1).reshape(5, 5, 3) / 75.0
         alpha2 = np.linspace(1, 0, 25).reshape(5, 5, 1)
         arr2 = np.concatenate([core2, alpha2], 2)
         data2 = xr.DataArray(arr2, dims=['y', 'x', 'bands'],

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1789,14 +1789,14 @@ class TestXRImage(unittest.TestCase):
         alpha1 = np.linspace(0, 1, 25).reshape(5, 5, 1)
         arr1 = np.concatenate([core1, alpha1], 2)
         data1 = xr.DataArray(arr1, dims=['y', 'x', 'bands'],
-                            coords={'bands': ['R', 'G', 'B', 'A']})
+                             coords={'bands': ['R', 'G', 'B', 'A']})
         img1 = xrimage.XRImage(data1)
 
         core2 = np.arange(75, 0, -1).reshape(5, 5, 3) / 75
         alpha2 = np.linspace(1, 0, 25).reshape(5, 5, 1)
         arr2 = np.concatenate([core2, alpha2], 2)
         data2 = xr.DataArray(arr2, dims=['y', 'x', 'bands'],
-                            coords={'bands': ['R', 'G', 'B', 'A']})
+                             coords={'bands': ['R', 'G', 'B', 'A']})
         img2 = xrimage.XRImage(data2)
 
         img3 = img1.blend(img2)
@@ -1808,11 +1808,11 @@ class TestXRImage(unittest.TestCase):
         np.testing.assert_allclose(
             img3.data.sel(bands="R").values,
             np.array(
-                [[1.        , 0.95833635, 0.9136842 , 0.8666667 , 0.8180645 ],
-                 [0.768815  , 0.72      , 0.6728228 , 0.62857145, 0.5885714 ],
-                 [0.55412847, 0.5264665 , 0.50666666, 0.495612  , 0.49394494],
-                 [0.5020408 , 0.52      , 0.5476586 , 0.5846154 , 0.63027024],
-                 [0.683871  , 0.7445614 , 0.81142855, 0.8835443 , 0.96]]))
+                [[1.,           0.95833635, 0.9136842,  0.8666667,  0.8180645],
+                 [0.768815,     0.72,       0.6728228,  0.62857145, 0.5885714],
+                 [0.55412847,   0.5264665,  0.50666666, 0.495612,   0.49394494],
+                 [0.5020408,    0.52,       0.5476586,  0.5846154,  0.63027024],
+                 [0.683871,     0.7445614,  0.81142855, 0.8835443,  0.96]]))
 
         with self.assertRaises(TypeError):
             img1.blend("Salekhard")

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1782,7 +1782,45 @@ class TestXRImage(unittest.TestCase):
         pass
 
     def test_blend(self):
-        pass
+        import xarray as xr
+        from trollimage import xrimage
+
+        core1 = np.arange(75).reshape(5, 5, 3) / 75
+        alpha1 = np.linspace(0, 1, 25).reshape(5, 5, 1)
+        arr1 = np.concatenate([core1, alpha1], 2)
+        data1 = xr.DataArray(arr1, dims=['y', 'x', 'bands'],
+                            coords={'bands': ['R', 'G', 'B', 'A']})
+        img1 = xrimage.XRImage(data1)
+
+        core2 = np.arange(75, 0, -1).reshape(5, 5, 3) / 75
+        alpha2 = np.linspace(1, 0, 25).reshape(5, 5, 1)
+        arr2 = np.concatenate([core2, alpha2], 2)
+        data2 = xr.DataArray(arr2, dims=['y', 'x', 'bands'],
+                            coords={'bands': ['R', 'G', 'B', 'A']})
+        img2 = xrimage.XRImage(data2)
+
+        img3 = img1.blend(img2)
+
+        np.testing.assert_allclose(
+                (alpha1 + alpha2 * (1 - alpha1)).squeeze(),
+                img3.data.sel(bands="A"))
+
+        np.testing.assert_allclose(
+            img3.data.sel(bands="R").values,
+            np.array(
+                [[1.        , 0.95833635, 0.9136842 , 0.8666667 , 0.8180645 ],
+                 [0.768815  , 0.72      , 0.6728228 , 0.62857145, 0.5885714 ],
+                 [0.55412847, 0.5264665 , 0.50666666, 0.495612  , 0.49394494],
+                 [0.5020408 , 0.52      , 0.5476586 , 0.5846154 , 0.63027024],
+                 [0.683871  , 0.7445614 , 0.81142855, 0.8835443 , 0.96]]))
+
+        with self.assertRaises(TypeError):
+            img1.blend("Salekhard")
+
+        wrongimg = xrimage.XRImage(
+                xr.DataArray(np.zeros((0, 0)), dims=("y", "x")))
+        with self.assertRaises(ValueError):
+            img1.blend(wrongimg)
 
     def test_replace_luminance(self):
         pass

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1064,7 +1064,7 @@ class XRImage(object):
         outa = srca + dsta * (1-srca)
         bi = {"bands": ["R", "G", "B"]}
         dstdata.loc[bi] = (src.data.loc[bi] * srca
-                + self.data.loc[bi] * dsta * (1-srca)) / outa
+                           + self.data.loc[bi] * dsta * (1-srca)) / outa
         for b in "RGB":
             dstdata.loc[{"bands": b}].values[outa.values == 0] = 0
         dstdata.loc[{"bands": "A"}] = outa

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1046,12 +1046,14 @@ class XRImage(object):
 
         if self.mode != "RGBA":
             raise ValueError(
-                    f"Expected self.mode='RGBA', got {self.mode!s}")
+                    "Expected self.mode='RGBA', got {md!s}".format(
+                        md=self.mode))
         elif not isinstance(src, XRImage):
-            raise TypeError(f"Expected XRImage, got {type(src)!s}")
+            raise TypeError("Expected XRImage, got {tp!s}".format(
+                tp=type(src)))
         elif src.mode != "RGBA":
-            raise ValueError(
-                    f"Expected src.mode='RGBA', got {src.mode!s}")
+            raise ValueError("Expected src.mode='RGBA', got {sm!s}".format(
+                sm=src.mode))
 
         dstdata = xr.DataArray(
                 np.empty(src.data.shape, dtype="f4"),

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1062,10 +1062,10 @@ class XRImage(object):
         srca = src.data.sel(bands="A")
         dsta = self.data.sel(bands="A")
         outa = srca + dsta * (1-srca)
+        bi = {"bands": ["R", "G", "B"]}
+        dstdata.loc[bi] = (src.data.loc[bi] * srca
+                + self.data.loc[bi] * dsta * (1-srca)) / outa
         for b in "RGB":
-            dstdata.loc[{"bands": b}] = (
-                    (src.data.sel(bands=b) * srca
-                        + self.data.sel(bands=b) * dsta * (1 - srca)) / outa)
             dstdata.loc[{"bands": b}].values[outa.values == 0] = 0
         dstdata.loc[{"bands": "A"}] = outa
         return self.__class__(dstdata)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1065,8 +1065,7 @@ class XRImage(object):
         bi = {"bands": ["R", "G", "B"]}
         dstdata.loc[bi] = (src.data.loc[bi] * srca
                            + self.data.loc[bi] * dsta * (1-srca)) / outa
-        for b in "RGB":
-            dstdata.loc[{"bands": b}].values[outa.values == 0] = 0
+        dstdata.loc[bi] = dstdata.loc[bi].where(outa != 0, 0)
         dstdata.loc[{"bands": "A"}] = outa
         return self.__class__(dstdata)
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1020,8 +1020,13 @@ class XRImage(object):
         .. math::
 
            \begin{cases}
-            \mathrm{out}_A = \mathrm{src}_A + \mathrm{dst}_A (1 - \mathrm{src}_A) \\
-            \mathrm{out}_{RGB} = \bigl( \mathrm{src}_{RGB} \mathrm{src}_A + \mathrm{dst}_{RGB} \mathrm{dst}_A \left( 1 - \mathrm{src}_A \right) \bigr) \div \mathrm{out}_A \\
+            \mathrm{out}_A =
+             \mathrm{src}_A + \mathrm{dst}_A (1 - \mathrm{src}_A) \\
+            \mathrm{out}_{RGB} =
+             \bigl(\mathrm{src}_{RGB}\mathrm{src}_A
+                 + \mathrm{dst}_{RGB} \mathrm{dst}_A
+                   \left(1 - \mathrm{src}_A \right) \bigr)
+             \div \mathrm{out}_A \\
             \mathrm{out}_A = 0 \Rightarrow \mathrm{out}_{RGB} = 0
            \end{cases}
 
@@ -1040,13 +1045,13 @@ class XRImage(object):
         # NB: docstring maths copy-pasta from enwiki
 
         if self.mode != "RGBA":
-            raise ValueError("Expected self.mode='RGBA', got "
-                f"{self.mode!s}")
+            raise ValueError(
+                    f"Expected self.mode='RGBA', got {self.mode!s}")
         elif not isinstance(src, XRImage):
             raise TypeError(f"Expected XRImage, got {type(src)!s}")
         elif src.mode != "RGBA":
-            raise ValueError("Expected src.mode='RGBA', got "
-                f"{src.mode!s}")
+            raise ValueError(
+                    f"Expected src.mode='RGBA', got {src.mode!s}")
 
         dstdata = xr.DataArray(
                 np.empty(src.data.shape, dtype="f4"),
@@ -1058,9 +1063,8 @@ class XRImage(object):
         for b in "RGB":
             dstdata.loc[{"bands": b}] = (
                     (src.data.sel(bands=b) * srca
-                        + self.data.sel(bands=b) * dsta * (1 - srca)
-                    ) / outa)
-            dstdata.loc[{"bands": b}].values[outa.values==0] = 0
+                        + self.data.sel(bands=b) * dsta * (1 - srca)) / outa)
+            dstdata.loc[{"bands": b}].values[outa.values == 0] = 0
         dstdata.loc[{"bands": "A"}] = outa
         return self.__class__(dstdata)
 


### PR DESCRIPTION
This PR implements the blend method for the XRImage class.
This method already exists on the simple Image class. It implements
alpha blending between two XRImage objects.  The XRImage implementation
leaves the original untouched and returns a third, new XRImage object.
The PR also adds documentation and unit tests.

 - [x] Tests added 
 - [x] Tests passed 
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` 
 - [x] Fully documented 
