### PR TITLE
Fix _FillValue not being respected when converting to alpha image

### DIFF
--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -449,11 +449,15 @@ class XRImage(object):
 
         If ``data`` is an integer type then the alpha band will be scaled
         to use the smallest (min) value as fully transparent and the largest
-        (max) value as fully opaque. For float types the alpha band spans
-        0 to 1.
+        (max) value as fully opaque. If a `_FillValue` attribute is found for
+        integer type data then it is used to identify null values in the data.
+        Otherwise xarray's `isnull` is used.
+
+        For float types the alpha band spans 0 to 1.
 
         """
-        null_mask = alpha if alpha is not None else self._create_alpha(data)
+        fill_value = data.attrs.get('_FillValue', None)  # integer fill value
+        null_mask = alpha if alpha is not None else self._create_alpha(data, fill_value)
         # if we are using integer data, then alpha needs to be min-int to max-int
         # otherwise for floats we want 0 to 1
         if np.issubdtype(data.dtype, np.integer):


### PR DESCRIPTION
I noticed while using convert that going from L to LA for integer fields was not holding on to the `_FillValue` attribute of the data. This was a problem for how I was palettizing VIIRS Active Fires data in Polar2Grid.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
