### PR TITLE
Add 'colors' and 'values' keyword arguments to Colormap

### DIFF
--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -88,9 +88,13 @@ class Colormap(object):
 
     """
 
-    def __init__(self, *tuples):
-        values = [a for (a, b) in tuples]
-        colors = [b for (a, b) in tuples]
+    def __init__(self, *tuples, **kwargs):
+        if 'colors' in kwargs and 'values' in kwargs:
+            values = kwargs['values']
+            colors = kwargs['colors']
+        else:
+            values = [a for (a, b) in tuples]
+            colors = [b for (a, b) in tuples]
         self.values = np.array(values)
         self.colors = np.array(colors)
 


### PR DESCRIPTION
Every time I create Colormap objects manually I find it difficult to create the tuples that have to be passed to the Colormap. This is especially difficult when I want to copy a Colormap since internally it already represents things as values/colors.

This PR adds keyword arguments `colors` and `values` to make creating a Colormap object a little easier.

I haven't added tests yet because I wanted to make sure @pnuu and @mraspaud didn't have any problems with this first.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
