### PR TITLE
Fix double format passing in saving functions

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -21,8 +21,7 @@
 
 # You should have received a copy of the GNU General Public License
 # along with mpop.  If not, see <http://www.gnu.org/licenses/>.
-"""Module for testing the imageo.image module.
-"""
+"""Module for testing the imageo.image module."""
 import os
 import sys
 import random
@@ -58,18 +57,15 @@ class CustomScheduler(object):
 
 
 class TestEmptyImage(unittest.TestCase):
-    """Class for testing the mpop.imageo.image module
-    """
+    """Class for testing the mpop.imageo.image module."""
 
     def setUp(self):
-        """Setup the test.
-        """
+        """Set up the test case."""
         self.img = image.Image()
         self.modes = ["L", "LA", "RGB", "RGBA", "YCbCr", "YCbCrA", "P", "PA"]
 
     def test_shape(self):
-        """Shape of an empty image.
-        """
+        """Shape of an empty image."""
         oldmode = self.img.mode
         for mode in self.modes:
             self.img.convert(mode)
@@ -77,13 +73,11 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_is_empty(self):
-        """Test if an image is empty.
-        """
+        """Test if an image is empty."""
         self.assertEqual(self.img.is_empty(), True)
 
     def test_clip(self):
-        """Clip an empty image.
-        """
+        """Clip an empty image."""
         oldmode = self.img.mode
         for mode in self.modes:
             self.img.convert(mode)
@@ -91,8 +85,7 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_convert(self):
-        """Convert an empty image.
-        """
+        """Convert an empty image."""
         for mode1 in self.modes:
             for mode2 in self.modes:
                 self.img.convert(mode1)
@@ -108,8 +101,7 @@ class TestEmptyImage(unittest.TestCase):
         self.assertRaises(ValueError, self.img.convert, randstr)
 
     def test_stretch(self):
-        """Stretch an empty image
-        """
+        """Stretch an empty image."""
         oldmode = self.img.mode
         for mode in self.modes:
             self.img.convert(mode)
@@ -136,8 +128,7 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_gamma(self):
-        """Gamma correction on an empty image.
-        """
+        """Gamma correction on an empty image."""
         oldmode = self.img.mode
         for mode in self.modes:
             self.img.convert(mode)
@@ -158,8 +149,7 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_invert(self):
-        """Invert an empty image.
-        """
+        """Invert an empty image."""
         oldmode = self.img.mode
         for mode in self.modes:
             self.img.convert(mode)
@@ -174,8 +164,7 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_pil_image(self):
-        """Return an empty PIL image.
-        """
+        """Return an empty PIL image."""
         oldmode = self.img.mode
         for mode in self.modes:
             self.img.convert(mode)
@@ -189,8 +178,7 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_putalpha(self):
-        """Add an alpha channel to en empty image
-        """
+        """Add an alpha channel to en empty image."""
         # Putting alpha channel to an empty image should not do anything except
         # change the mode if necessary.
         oldmode = self.img.mode
@@ -212,8 +200,7 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_save(self):
-        """Save an empty image.
-        """
+        """Save an empty image."""
         oldmode = self.img.mode
         for mode in self.modes:
             self.img.convert(mode)
@@ -222,8 +209,7 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_replace_luminance(self):
-        """Replace luminance in an empty image.
-        """
+        """Replace luminance in an empty image."""
         oldmode = self.img.mode
         for mode in self.modes:
             self.img.convert(mode)
@@ -234,13 +220,11 @@ class TestEmptyImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_resize(self):
-        """Resize an empty image.
-        """
+        """Resize an empty image."""
         self.assertRaises(ValueError, self.img.resize, (10, 10))
 
     def test_merge(self):
-        """Merging of an empty image with another.
-        """
+        """Merging of an empty image with another."""
         newimg = image.Image()
         self.assertRaises(ValueError, self.img.merge, newimg)
         newimg = image.Image(np.array([[1, 2], [3, 4]]))
@@ -250,20 +234,16 @@ class TestEmptyImage(unittest.TestCase):
 
 
 class TestImageCreation(unittest.TestCase):
-    """Class for testing the mpop.imageo.image module
-    """
+    """Class for testing the mpop.imageo.image module."""
 
     def setUp(self):
-        """Setup the test.
-        """
+        """Set up the test case."""
         self.img = {}
         self.modes = ["L", "LA", "RGB", "RGBA", "YCbCr", "YCbCrA", "P", "PA"]
         self.modes_len = [1, 2, 3, 4, 3, 4, 1, 2]
 
     def test_creation(self):
-        """Creation of an image.
-        """
-
+        """Test creation of an image."""
         self.assertRaises(TypeError, image.Image,
                           channels=random.randint(1, 1000))
         self.assertRaises(TypeError, image.Image,
@@ -338,12 +318,10 @@ class TestImageCreation(unittest.TestCase):
 
 
 class TestRegularImage(unittest.TestCase):
-    """Class for testing the mpop.imageo.image module
-    """
+    """Class for testing the mpop.imageo.image module."""
 
     def setUp(self):
-        """Setup the test.
-        """
+        """Set up the test case."""
         one_channel = np.random.rand(random.randint(1, 10),
                                      random.randint(1, 10))
         self.rand_img = image.Image(channels=[one_channel] * 3,
@@ -370,8 +348,7 @@ class TestRegularImage(unittest.TestCase):
         os.chmod(self.tempdir, 0o444)
 
     def test_shape(self):
-        """Shape of an image.
-        """
+        """Shape of an image."""
         oldmode = self.img.mode
         for mode in self.modes:
             if mode == "P" or mode == "PA":
@@ -381,13 +358,11 @@ class TestRegularImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_is_empty(self):
-        """Test if an image is empty.
-        """
+        """Test if an image is empty."""
         self.assertEqual(self.img.is_empty(), False)
 
     def test_clip(self):
-        """Clip an image.
-        """
+        """Clip an image."""
         oldmode = self.img.mode
         for mode in self.modes:
             if mode == "P" or mode == "PA":
@@ -399,8 +374,7 @@ class TestRegularImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_convert(self):
-        """Convert an image.
-        """
+        """Convert an image."""
         i = 0
         for mode1 in self.modes:
             j = 0
@@ -437,8 +411,7 @@ class TestRegularImage(unittest.TestCase):
         self.assertRaises(ValueError, self.img.convert, randstr)
 
     def test_stretch(self):
-        """Stretch an image.
-        """
+        """Stretch an image."""
         oldmode = self.img.mode
 
         for mode in "L":
@@ -479,8 +452,7 @@ class TestRegularImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_gamma(self):
-        """Gamma correction on an image.
-        """
+        """Gamma correction on an image."""
         oldmode = self.img.mode
         for mode in self.modes:
             if mode == "P" or mode == "PA":
@@ -519,8 +491,7 @@ class TestRegularImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_invert(self):
-        """Invert an image.
-        """
+        """Invert an image."""
         oldmode = self.img.mode
         for mode in self.modes:
             if mode == "P" or mode == "PA":
@@ -543,11 +514,8 @@ class TestRegularImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_pil_image(self):
-        """Return an PIL image.
-        """
-
+        """Return an PIL image."""
         # FIXME: Should test on palette images
-
         oldmode = self.img.mode
         for mode in self.modes:
             if (mode == "YCbCr" or
@@ -561,8 +529,7 @@ class TestRegularImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_putalpha(self):
-        """Add an alpha channel.
-        """
+        """Add an alpha channel."""
         # Putting alpha channel to an image should not do anything except
         # change the mode if necessary.
         oldmode = self.img.mode
@@ -590,8 +557,7 @@ class TestRegularImage(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith('win'),
                      "Read-only tmp dir not working under Windows")
     def test_save(self):
-        """Save an image.
-        """
+        """Save an image."""
         oldmode = self.img.mode
         for mode in self.modes:
             if (mode == "YCbCr" or
@@ -614,8 +580,7 @@ class TestRegularImage(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith('win'),
                      "Read-only tmp dir not working under Windows")
     def test_save_jpeg(self):
-        """Save a jpeg image.
-        """
+        """Save a jpeg image."""
         oldmode = self.img.mode
         self.img.convert('L')
         self.img.save("test.jpg")
@@ -630,8 +595,7 @@ class TestRegularImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_replace_luminance(self):
-        """Replace luminance in an image.
-        """
+        """Replace luminance in an image."""
         oldmode = self.img.mode
         for mode in self.modes:
             if (mode == "P" or
@@ -651,8 +615,7 @@ class TestRegularImage(unittest.TestCase):
         self.img.convert(oldmode)
 
     def test_resize(self):
-        """Resize an image.
-        """
+        """Resize an image."""
         self.img.resize((6, 6))
         res = np.array([[0, 0, 0.5, 0.5, 0.5, 0.5],
                         [0, 0, 0.5, 0.5, 0.5, 0.5],
@@ -667,8 +630,7 @@ class TestRegularImage(unittest.TestCase):
         self.assertTrue(np.all(res == self.img.channels[0]))
 
     def test_merge(self):
-        """Merging of an image with another.
-        """
+        """Merging of an image with another."""
         newimg = image.Image()
         self.assertRaises(ValueError, self.img.merge, newimg)
         newimg = image.Image(np.array([[1, 2], [3, 4]]))
@@ -686,17 +648,16 @@ class TestRegularImage(unittest.TestCase):
                                EPSILON))
 
     def tearDown(self):
-        """Clean up the mess.
-        """
+        """Clean up the mess."""
         os.chmod(self.tempdir, 0o777)
         os.rmdir(self.tempdir)
 
 
 class TestFlatImage(unittest.TestCase):
-    """Test a flat image, ie an image where min == max.
-    """
+    """Test a flat image, ie an image where min == max."""
 
     def setUp(self):
+        """Set up the test case."""
         channel = np.ma.array([[0, 0.5, 0.5], [0.5, 0.25, 0.25]],
                               mask=[[1, 1, 1], [1, 1, 0]])
         self.img = image.Image(channels=[channel] * 3,
@@ -704,8 +665,7 @@ class TestFlatImage(unittest.TestCase):
         self.modes = ["L", "LA", "RGB", "RGBA", "YCbCr", "YCbCrA", "P", "PA"]
 
     def test_stretch(self):
-        """Stretch a flat image.
-        """
+        """Stretch a flat image."""
         self.img.stretch()
         self.assertTrue(self.img.channels[0].shape == (2, 3) and
                         np.ma.count_masked(self.img.channels[0]) == 5)
@@ -724,10 +684,10 @@ class TestFlatImage(unittest.TestCase):
 
 
 class TestNoDataImage(unittest.TestCase):
-    """Test an image filled with no data.
-    """
+    """Test an image filled with no data."""
 
     def setUp(self):
+        """Set up the test case."""
         channel = np.ma.array([[0, 0.5, 0.5], [0.5, 0.25, 0.25]],
                               mask=[[1, 1, 1], [1, 1, 1]])
         self.img = image.Image(channels=[channel] * 3,
@@ -735,8 +695,7 @@ class TestNoDataImage(unittest.TestCase):
         self.modes = ["L", "LA", "RGB", "RGBA", "YCbCr", "YCbCrA", "P", "PA"]
 
     def test_stretch(self):
-        """Stretch a no data image.
-        """
+        """Stretch a no data image."""
         self.img.stretch()
         self.assertTrue(self.img.channels[0].shape == (2, 3))
         self.img.stretch("crude")
@@ -752,16 +711,16 @@ class TestNoDataImage(unittest.TestCase):
 def random_string(length,
                   choices="abcdefghijklmnopqrstuvwxyz"
                           "ABCDEFGHIJKLMNOPQRSTUVWXYZ"):
-    """Generates a random string with elements from *set* of the specified
-    *length*.
-    """
+    """Generate a random string with elements from *set* of the specified *length*."""
     return "".join([random.choice(choices)
                     for dummy in range(length)])
 
 
 class TestXRImage(unittest.TestCase):
+    """Test XRImage objects."""
 
     def test_init(self):
+        """Test object initialization."""
         import xarray as xr
         from trollimage import xrimage
         data = xr.DataArray([[0, 0.5, 0.5], [0.5, 0.25, 0.25]], dims=['y', 'x'])
@@ -796,6 +755,7 @@ class TestXRImage(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith('win'),
                      "'NamedTemporaryFile' not supported on Windows")
     def test_save(self):
+        """Test saving."""
         import xarray as xr
         import dask.array as da
         from dask.delayed import Delayed
@@ -1328,6 +1288,7 @@ class TestXRImage(unittest.TestCase):
         self.assertTrue(np.allclose(img.data.values, res, atol=1.e-6))
 
     def test_histogram_stretch(self):
+        """Test histogram stretching."""
         import xarray as xr
         from trollimage import xrimage
 
@@ -1369,6 +1330,7 @@ class TestXRImage(unittest.TestCase):
         self.assertTrue(np.allclose(img.data.values, res, atol=1.e-6))
 
     def test_logarithmic_stretch(self):
+        """Test logarithmic strecthing."""
         import xarray as xr
         from trollimage import xrimage
 
@@ -1410,7 +1372,7 @@ class TestXRImage(unittest.TestCase):
         self.assertTrue(np.allclose(img.data.values, res, atol=1.e-6))
 
     def test_weber_fechner_stretch(self):
-        """S=2.3klog10I+C """
+        """Test applying S=2.3klog10I+C to the data."""
         import xarray as xr
         from trollimage import xrimage
 
@@ -1452,27 +1414,35 @@ class TestXRImage(unittest.TestCase):
         self.assertTrue(np.allclose(img.data.values, res, atol=1.e-6))
 
     def test_jpeg_save(self):
+        """Test saving to jpeg."""
         pass
 
     def test_gtiff_save(self):
+        """Test saving to geotiff."""
         pass
 
     def test_save_masked(self):
+        """Test saving masked data."""
         pass
 
     def test_LA_save(self):
+        """Test LA saving."""
         pass
 
     def test_L_save(self):
+        """Test L saving."""
         pass
 
     def test_P_save(self):
+        """Test P saving."""
         pass
 
     def test_PA_save(self):
+        """Test PA saving."""
         pass
 
     def test_convert_modes(self):
+        """Test modes convertions."""
         import dask
         import xarray as xr
         from trollimage import xrimage
@@ -1782,7 +1752,7 @@ class TestXRImage(unittest.TestCase):
         self.assertTupleEqual((2, 4), bw.colors.shape)
 
     def test_stack(self):
-
+        """Test stack."""
         import xarray as xr
         from trollimage import xrimage
 
@@ -1810,9 +1780,11 @@ class TestXRImage(unittest.TestCase):
         np.testing.assert_allclose(bkg.data, res.data, rtol=1e-05)
 
     def test_merge(self):
+        """Test merge."""
         pass
 
     def test_blend(self):
+        """Test blend."""
         import xarray as xr
         from trollimage import xrimage
 
@@ -1854,13 +1826,15 @@ class TestXRImage(unittest.TestCase):
             img1.blend(wrongimg)
 
     def test_replace_luminance(self):
+        """Test luminance replacement."""
         pass
 
     def test_putalpha(self):
+        """Test putalpha."""
         pass
 
     def test_show(self):
-        """Test that the show commands calls PIL.show"""
+        """Test that the show commands calls PIL.show."""
         import xarray as xr
         from trollimage import xrimage
 
@@ -1873,7 +1847,7 @@ class TestXRImage(unittest.TestCase):
 
 
 def suite():
-    """The suite for test_image."""
+    """Create the suite for test_image."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestEmptyImage))

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -752,6 +752,19 @@ class TestXRImage(unittest.TestCase):
         img = xrimage.XRImage(data)
         self.assertEqual(img.mode, 'YCbCrA')
 
+    def test_regression_double_format_save(self):
+        """Test that double format information isn't passed to save."""
+        import xarray as xr
+        from trollimage import xrimage
+
+        data = xr.DataArray(np.arange(75).reshape(5, 5, 3) / 74., dims=[
+            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+        with mock.patch.object(xrimage.XRImage, 'pil_save') as pil_save:
+            img = xrimage.XRImage(data)
+
+            img.save(filename='bla.png', fformat='png', format='png')
+            self.assertNotIn('format', pil_save.call_args_list[0][1])
+
     @unittest.skipIf(sys.platform.startswith('win'),
                      "'NamedTemporaryFile' not supported on Windows")
     def test_save(self):

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -21,7 +21,7 @@
 
 # You should have received a copy of the GNU General Public License
 # along with mpop.  If not, see <http://www.gnu.org/licenses/>.
-"""Module for testing the imageo.image module."""
+"""Module for testing the image and xrimage modules."""
 import os
 import sys
 import random

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -259,7 +259,8 @@ class XRImage(object):
                                      saving with rasterio, used with
                                      keep_palette=True. Should be uint8.
             format_kwargs: Additional format options to pass to `rasterio`
-                           or `PIL` saving methods.
+                           or `PIL` saving methods. Any format argument passed
+                           at this stage would be superseeded by `fformat`.
 
         Returns:
             Either `None` if `compute` is True or a `dask.Delayed` object or

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -272,7 +272,7 @@ class XRImage(object):
 
         """
         kwformat = format_kwargs.pop('format', None)
-        fformat = fformat or kwformat or os.path.splitext(filename)[1][1:4]
+        fformat = fformat or kwformat or os.path.splitext(filename)[1][1:]
         if fformat in ('tif', 'jp2') and rasterio:
             return self.rio_save(filename, fformat=fformat,
                                  fill_value=fill_value, compute=compute,
@@ -293,7 +293,7 @@ class XRImage(object):
           img.rio_save('myfile.tif', overviews=[2, 4, 8, 16])
 
         """
-        fformat = fformat or os.path.splitext(filename)[1][1:4]
+        fformat = fformat or os.path.splitext(filename)[1][1:]
         drivers = {'jpg': 'JPEG',
                    'png': 'PNG',
                    'tif': 'GTiff',
@@ -393,7 +393,7 @@ class XRImage(object):
         lack of support. See also :meth:`save`.
 
         """
-        fformat = fformat or os.path.splitext(filename)[1][1:4]
+        fformat = fformat or os.path.splitext(filename)[1][1:]
         fformat = check_image_format(fformat)
 
         if fformat == 'png':
@@ -1016,7 +1016,7 @@ class XRImage(object):
 
     @staticmethod
     def _palettize(data, colormap):
-        """Operate in a dask-friendly maner."""
+        """Operate in a dask-friendly manner."""
         # returns data and palette, only need data
         return colormap.palettize(data)[0]
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -270,7 +270,8 @@ class XRImage(object):
             the caller.
 
         """
-        fformat = fformat or os.path.splitext(filename)[1][1:4]
+        kwformat = format_kwargs.pop('format', None)
+        fformat = fformat or kwformat or os.path.splitext(filename)[1][1:4]
         if fformat in ('tif', 'jp2') and rasterio:
             return self.rio_save(filename, fformat=fformat,
                                  fill_value=fill_value, compute=compute,

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -21,12 +21,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""This module defines the XRImage class. It overlaps largely with the PIL
-library, but has the advantage of using :class:`~xarray.DataArray` objects
-backed by :class:`dask arrays <dask.array.Array>` as pixel arrays. This
-allows for invalid values to be tracked, metadata to be assigned, and
-stretching to be lazy evaluated. With the optional ``rasterio`` library
-installed dask array chunks can be saved in parallel.
+"""This module defines the XRImage class.
+
+It overlaps largely with the PIL library, but has the advantage of using
+:class:`~xarray.DataArray` objects backed by :class:`dask arrays
+<dask.array.Array>` as pixel arrays. This allows for invalid values to
+be tracked, metadata to be assigned, and stretching to be lazy
+evaluated. With the optional ``rasterio`` library installed dask array
+chunks can be saved in parallel.
 
 """
 
@@ -96,12 +98,14 @@ class RIOFile(object):
                          indexes=indexes)
 
     def open(self, mode=None):
+        """Open the file."""
         mode = mode or self.mode
         if self._closed:
             self.rfile = rasterio.open(self.path, mode, **self.kwargs)
             self._closed = False
 
     def close(self):
+        """Close the file."""
         if not self._closed:
             if self.overviews:
                 logger.debug('Building overviews %s', str(self.overviews))
@@ -119,6 +123,7 @@ class RIOFile(object):
         self.close()
 
     def __del__(self):
+        """Delete the instance."""
         try:
             self.close()
         except (IOError, OSError):
@@ -168,8 +173,10 @@ def color_interp(data):
 class XRImage(object):
     """Image class using an :class:`xarray.DataArray` as internal storage.
 
-    It can be saved to a variety of image formats, but if Rasterio is installed,
-    it can save to geotiff and jpeg2000 with geographical information.
+    It can be saved to a variety of image formats, but if Rasterio is
+    installed, it can save to geotiff and jpeg2000 with geographical
+    information.
+
     """
 
     def __init__(self, data):
@@ -380,8 +387,9 @@ class XRImage(object):
                  compute=True, **format_kwargs):
         """Save the image to the given *filename* using PIL.
 
-        For now, the compression level [0-9] is ignored, due to PIL's lack of
-        support. See also :meth:`save`.
+        For now, the compression level [0-9] is ignored, due to PIL's
+        lack of support. See also :meth:`save`.
+
         """
         fformat = fformat or os.path.splitext(filename)[1][1:4]
         fformat = check_image_format(fformat)
@@ -402,6 +410,7 @@ class XRImage(object):
         Inspired by:
         public domain, Nick Galbreath
         http://blog.modp.com/2007/08/python-pil-and-png-metadata-take-2.html
+
         """
         reserved = ('interlace', 'gamma', 'dpi', 'transparency', 'aspect')
 
@@ -531,8 +540,7 @@ class XRImage(object):
         return data
 
     def _l2rgb(self, mode):
-        """Convert from L (black and white) to RGB.
-        """
+        """Convert from L (black and white) to RGB."""
         self._check_modes(("L", "LA"))
 
         bands = ["L"] * 3
@@ -543,6 +551,7 @@ class XRImage(object):
         return data
 
     def convert(self, mode):
+        """Convert image to *mode*."""
         if mode == self.mode:
             return self.__class__(self.data)
 
@@ -588,7 +597,7 @@ class XRImage(object):
         return new_img
 
     def _finalize(self, fill_value=None, dtype=np.uint8, keep_palette=False, cmap=None):
-        """Wrapper around 'finalize' method for backwards compatibility."""
+        """Wrap around 'finalize' method for backwards compatibility."""
         import warnings
         warnings.warn("'_finalize' is deprecated, use 'finalize' instead.",
                       DeprecationWarning)
@@ -597,13 +606,14 @@ class XRImage(object):
     def finalize(self, fill_value=None, dtype=np.uint8, keep_palette=False, cmap=None):
         """Finalize the image to be written to an output file.
 
-        This adds an alpha band or fills data with a fill_value (if specified).
-        It also scales float data to the output range of the data type (0-255
-        for uint8, default). For integer input data this method assumes the
-        data is already scaled to the proper desired range. It will still fill
-        in invalid values and add an alpha band if needed. Integer input
-        data's fill value is determined by a special ``_FillValue`` attribute
-        in the ``DataArray`` ``.attrs`` dictionary.
+        This adds an alpha band or fills data with a fill_value (if
+        specified). It also scales float data to the output range of the
+        data type (0-255 for uint8, default). For integer input data
+        this method assumes the data is already scaled to the proper
+        desired range. It will still fill in invalid values and add an
+        alpha band if needed. Integer input data's fill value is
+        determined by a special ``_FillValue`` attribute in the
+        ``DataArray`` ``.attrs`` dictionary.
 
         """
         if keep_palette and not self.mode.startswith('P'):
@@ -677,12 +687,13 @@ class XRImage(object):
     def gamma(self, gamma=1.0):
         """Apply gamma correction to the channels of the image.
 
-        If *gamma* is a
-        tuple, then it should have as many elements as the channels of the
-        image, and the gamma correction is applied elementwise. If *gamma* is a
-        number, the same gamma correction is applied on every channel, if there
-        are several channels in the image. The behaviour of :func:`gamma` is
-        undefined outside the normal [0,1] range of the channels.
+        If *gamma* is a tuple, then it should have as many elements as
+        the channels of the image, and the gamma correction is applied
+        elementwise. If *gamma* is a number, the same gamma correction
+        is applied on every channel, if there are several channels in
+        the image. The behaviour of :func:`gamma` is undefined outside
+        the normal [0,1] range of the channels.
+
         """
         if isinstance(gamma, (list, tuple)):
             gamma = self.xrify_tuples(gamma)
@@ -698,14 +709,16 @@ class XRImage(object):
     def stretch(self, stretch="crude", **kwargs):
         """Apply stretching to the current image.
 
-        The value of *stretch* sets the type of stretching applied. The values
-        "histogram", "linear", "crude" (or "crude-stretch") perform respectively
-        histogram equalization, contrast stretching (with 5% cutoff on both
-        sides), and contrast stretching without cutoff. The value "logarithmic"
-        or "log" will do a logarithmic enhancement towards white. If a tuple or
-        a list of two values is given as input, then a contrast stretching is
-        performed with the values as cutoff. These values should be normalized
-        in the range [0.0,1.0].
+        The value of *stretch* sets the type of stretching applied. The
+        values "histogram", "linear", "crude" (or "crude-stretch")
+        perform respectively histogram equalization, contrast stretching
+        (with 5% cutoff on both sides), and contrast stretching without
+        cutoff. The value "logarithmic" or "log" will do a logarithmic
+        enhancement towards white. If a tuple or a list of two values is
+        given as input, then a contrast stretching is performed with the
+        values as cutoff. These values should be normalized in the range
+        [0.0,1.0].
+
         """
         logger.debug("Applying stretch %s with parameters %s",
                      stretch, str(kwargs))
@@ -735,7 +748,7 @@ class XRImage(object):
 
     @staticmethod
     def _compute_quantile(data, dims, cutoffs):
-        """Helper method for stretch_linear.
+        """Compute quantile for stretch_linear.
 
         Dask delayed functions need to be non-internal functions (created
         inside a function) to be serializable on a multi-process scheduler.
@@ -756,6 +769,7 @@ class XRImage(object):
         """Stretch linearly the contrast of the current image.
 
         Use *cutoffs* for left and right trimming.
+
         """
         logger.debug("Perform a linear contrast stretch.")
 
@@ -786,8 +800,9 @@ class XRImage(object):
     def crude_stretch(self, min_stretch=None, max_stretch=None):
         """Perform simple linear stretching.
 
-        This is done without any cutoff on the current image and normalizes to
-        the [0,1] range.
+        This is done without any cutoff on the current image and
+        normalizes to the [0,1] range.
+
         """
         if min_stretch is None:
             non_band_dims = tuple(x for x in self.data.dims if x != 'bands')
@@ -892,6 +907,7 @@ class XRImage(object):
         p = k.ln(S/S0)
         p is perception, S is the stimulus, S0 is the stimulus threshold (the
         highest unpercieved stimulus), and k is the factor.
+
         """
         attrs = self.data.attrs
         self.data = k * xu.log(self.data / s0)
@@ -905,6 +921,7 @@ class XRImage(object):
 
         Note: 'Inverting' means that black becomes white, and vice-versa, not
         that the values are negated !
+
         """
         logger.debug("Applying invert with parameters %s", str(invert))
         if isinstance(invert, (tuple, list)):
@@ -919,8 +936,7 @@ class XRImage(object):
         self.data.attrs = attrs
 
     def stack(self, img):
-        """Stack the provided image on top of the current image.
-        """
+        """Stack the provided image on top of the current image."""
         # TODO: Conversions between different modes with notification
         # to the user, i.e. proper logging
         if self.mode != img.mode:
@@ -929,8 +945,10 @@ class XRImage(object):
         self.data = self.data.where(img.data.isnull(), img.data)
 
     def merge(self, img):
-        """Use the provided image as background for the current *img* image,
-        that is if the current image has missing data.
+        """Use the provided image as background for the current *img* image.
+
+        That is if the current image has missing data.
+
         """
         raise NotImplementedError("This method has not be implemented for "
                                   "xarray support.")
@@ -966,7 +984,6 @@ class XRImage(object):
             Works only on "L" or "LA" images.
 
         """
-
         if self.mode not in ("L", "LA"):
             raise ValueError("Image should be grayscale to colorize")
 
@@ -997,7 +1014,7 @@ class XRImage(object):
 
     @staticmethod
     def _palettize(data, colormap):
-        """Helper for dask-friendly palettize operation."""
+        """Operate in a dask-friendly maner."""
         # returns data and palette, only need data
         return colormap.palettize(data)[0]
 
@@ -1009,7 +1026,6 @@ class XRImage(object):
             Works only on "L" or "LA" images.
 
         """
-
         if self.mode not in ("L", "LA"):
             raise ValueError("Image should be grayscale to colorize")
 


### PR DESCRIPTION
When passing the format as an item in the kwargs to `img.save`, the `format` argument would be passed twice to the underlying functions, making the process crash.

 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
