### PR TITLE
Add ability to use AreaDefinitions new "crs" property

### DIFF
--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -327,7 +327,11 @@ class XRImage(object):
                                          photometric_map[mode.upper()])
 
             try:
-                crs = rasterio.crs.CRS(data.attrs['area'].proj_dict)
+                area = data.attrs['area']
+                if hasattr(area, 'crs'):
+                    crs = rasterio.crs.CRS.from_wkt(area.crs.to_wkt())
+                else:
+                    crs = rasterio.crs.CRS(data.attrs['area'].proj_dict)
                 west, south, east, north = data.attrs['area'].area_extent
                 height, width = data.sizes['y'], data.sizes['x']
                 transform = rasterio.transform.from_bounds(west, south,


### PR DESCRIPTION
See https://github.com/pytroll/pyresample/pull/196

The above PR will add a `area_def.crs` property which is a pyproj CRS object. It was recommended to use WKT to properly convert some projections between different systems by rasterio and pyproj developers (like `nsper` and `ob_tran`) since `+wktext` was a hacky solution in past versions of these libraries.

This PR checks if the `crs` property exists and uses it by converting to WellKnownText (wkt) then giving that to rasterio's CRS object's `from_wkt` method. Otherwise it will fallback to letting rasterio's CRS object guess based on the value of `area_def.proj_dcit`.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
