### PR TITLE
Add enhancement-history to the image

### DIFF
--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -829,7 +829,7 @@ class XRImage(object):
         else:
             scale_factor = 1.0 / delta
         attrs = self.data.attrs
-        offset = - min_stretch * scale_factor
+        offset = -min_stretch * scale_factor
         self.data *= scale_factor
         self.data += offset
         self.data.attrs = attrs

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -177,6 +177,9 @@ class XRImage(object):
     installed, it can save to geotiff and jpeg2000 with geographical
     information.
 
+    The enhancements functions are recording some parameters in the image's
+    data attribute called `enhancement_history`.
+
     """
 
     def __init__(self, data):


### PR DESCRIPTION
In some cases, it is necessary to have access to the history of enhancements to an image, eg when the reading software need to be able to recover some of the values before transformation.
This PR adds a new `enhancement_history` attribute of the data (DataArray) of the XRImage object, recording the parameters of the enhancements.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
