### PR TITLE
Fix WKT version used to convert CRS to GeoTIFF CRS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
         - CONDA_CHANNEL_PRIORITY=True
 
 install:
-    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
 script: coverage run --source=trollimage setup.py test
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,10 @@ environment:
       NUMPY_VERSION: "stable"
 
 install:
-    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+#    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+    - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "activate test"
+    - "conda activate test"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -48,6 +48,8 @@ try:
     import rasterio
 except ImportError:
     rasterio = None
+else:
+    import osgeo.gdal
 
 try:
     # rasterio 1.0+
@@ -331,7 +333,7 @@ class XRImage(object):
 
             try:
                 area = data.attrs['area']
-                if hasattr(area, 'crs'):
+                if hasattr(area, 'crs') and osgeo.gdal.VersionInfo().startswith('3'):
                     crs = rasterio.crs.CRS.from_wkt(area.crs.to_wkt(version='WKT1_GDAL'))
                 else:
                     crs = rasterio.crs.CRS(data.attrs['area'].proj_dict)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -332,7 +332,7 @@ class XRImage(object):
             try:
                 area = data.attrs['area']
                 if hasattr(area, 'crs'):
-                    crs = rasterio.crs.CRS.from_wkt(area.crs.to_wkt())
+                    crs = rasterio.crs.CRS.from_wkt(area.crs.to_wkt(version='WKT1_GDAL'))
                 else:
                     crs = rasterio.crs.CRS(data.attrs['area'].proj_dict)
                 west, south, east, north = data.attrs['area'].area_extent

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -48,8 +48,6 @@ try:
     import rasterio
 except ImportError:
     rasterio = None
-else:
-    import osgeo.gdal
 
 try:
     # rasterio 1.0+
@@ -333,8 +331,12 @@ class XRImage(object):
 
             try:
                 area = data.attrs['area']
-                if hasattr(area, 'crs') and osgeo.gdal.VersionInfo().startswith('3'):
-                    crs = rasterio.crs.CRS.from_wkt(area.crs.to_wkt(version='WKT1_GDAL'))
+                if rasterio.__gdal_version__ >= '3':
+                    wkt_version = 'WKT2_2018'
+                else:
+                    wkt_version = 'WKT1_GDAL'
+                if hasattr(area, 'crs'):
+                    crs = rasterio.crs.CRS.from_wkt(area.crs.to_wkt(version=wkt_version))
                 else:
                     crs = rasterio.crs.CRS(data.attrs['area'].proj_dict)
                 west, south, east, north = data.attrs['area'].area_extent


### PR DESCRIPTION
Trying to save a geotiff with a projection of "EPSG:3035" raises an error because rasterio/gdal doesn't like the WKT (well known text) that is used to represent it. See https://github.com/pyproj4/pyproj/issues/357 for more information.

I need to add a test and I'm still not sure the WKT version I added is the "best" version. This shows where and why the Satpy tests are failing though.

Error seen:

> CPLE_AppDefinedError: Only OGC WKT Projections supported for writing to GeoTIFF.  PROJCRS["ETRS89 / LAEA Europe",BASEGEOGCRS["ETRS89",DATUM["European Terrestrial Reference System 1989",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],ID["EPSG",4258]],CONVERSION["Europe Equal Area 2001",METHOD["Lambert Azimuthal Equal Area",ID["EPSG",9820]],PARAMETER["Latitude of natural origin",52,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],PARAMETER["Longitude of natural origin",10,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],PARAMETER["False easting",4321000,LENGTHUNIT["metre",1],ID["EPSG",8806]],PARAMETER["False northing",3210000,LENGTHUNIT["metre",1],ID["EPSG",8807]]],CS["Cartesian",2],AXIS["northing (Y)",north,ORDER[1],LENGTHUNIT["metre",1]],AXIS["easting (X)",east,ORDER[2],LENGTHUNIT["metre",1]],USAGE[SCOPE["unknown"],AREA["Europe - ETRS89"],BBOX[32.88,-16.1,84.17,40.18]],ID["EPSG",3035]] not supported.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
