### PR TITLE
Add the `apply_pil` method

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -23,12 +23,15 @@
 # along with mpop.  If not, see <http://www.gnu.org/licenses/>.
 """Module for testing the image and xrimage modules."""
 import os
-import sys
 import random
-import unittest
+import sys
 import tempfile
+import unittest
+from collections import OrderedDict
 from tempfile import NamedTemporaryFile
+
 import numpy as np
+
 from trollimage import image
 
 try:
@@ -1884,7 +1887,7 @@ class TestXRImage(unittest.TestCase):
         data = xr.DataArray(np_data, dims=[
             'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
 
-        dummy_args = [(), {}]
+        dummy_args = [(), {'image_mda': OrderedDict()}]
 
         def dummy_fun(pil_obj, *args, **kwargs):
             dummy_args[0] = args
@@ -1907,9 +1910,9 @@ class TestXRImage(unittest.TestCase):
         res = img.apply_pil(dummy_fun, 'RGB',
                             fun_args=('Hey', 'Jude'),
                             fun_kwargs={'chorus': "La lala lalalala"})
-        self.assertEqual(dummy_args, [(), {}])
+        self.assertEqual(dummy_args, [(), {'image_mda': OrderedDict()}])
         res.data.data.compute()
-        self.assertEqual(dummy_args, [('Hey', 'Jude'), {'chorus': "La lala lalalala"}])
+        self.assertEqual(dummy_args, [('Hey', 'Jude'), {'chorus': "La lala lalalala", 'image_mda': OrderedDict()}])
 
 
 def suite():

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1615,6 +1615,18 @@ class TestXRImage(unittest.TestCase):
             self.assertTrue(img2.mode == 'RGBA')
             self.assertTrue(len(img2.data.coords['bands']) == 4)
 
+    def test_final_mode(self):
+        """Test final_mode."""
+        import xarray as xr
+        from trollimage import xrimage
+
+        # numpy array image
+        data = xr.DataArray(np.arange(75).reshape(5, 5, 3), dims=[
+            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+        img = xrimage.XRImage(data)
+        self.assertEqual(img.final_mode(None), 'RGBA')
+        self.assertEqual(img.final_mode(0), 'RGB')
+
     def test_colorize(self):
         """Test colorize with an RGB colormap."""
         import xarray as xr

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1887,7 +1887,7 @@ class TestXRImage(unittest.TestCase):
         data = xr.DataArray(np_data, dims=[
             'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
 
-        dummy_args = [(), {'image_mda': OrderedDict()}]
+        dummy_args = [(OrderedDict(), ), {}]
 
         def dummy_fun(pil_obj, *args, **kwargs):
             dummy_args[0] = args
@@ -1910,9 +1910,9 @@ class TestXRImage(unittest.TestCase):
         res = img.apply_pil(dummy_fun, 'RGB',
                             fun_args=('Hey', 'Jude'),
                             fun_kwargs={'chorus': "La lala lalalala"})
-        self.assertEqual(dummy_args, [(), {'image_mda': OrderedDict()}])
+        self.assertEqual(dummy_args, [({}, ), {}])
         res.data.data.compute()
-        self.assertEqual(dummy_args, [('Hey', 'Jude'), {'chorus': "La lala lalalala", 'image_mda': OrderedDict()}])
+        self.assertEqual(dummy_args, [(OrderedDict(), 'Hey', 'Jude'), {'chorus': "La lala lalalala"}])
 
 
 def suite():

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1907,9 +1907,9 @@ class TestXRImage(unittest.TestCase):
         res = img.apply_pil(dummy_fun, 'RGB',
                             fun_args=('Hey', 'Jude'),
                             fun_kwargs={'chorus': "La lala lalalala"})
-        assert dummy_args == [(), {}]
+        self.assertEqual(dummy_args, [(), {}])
         res.data.data.compute()
-        assert dummy_args == [('Hey', 'Jude'), {'chorus': "La lala lalalala"}]
+        self.assertEqual(dummy_args, [('Hey', 'Jude'), {'chorus': "La lala lalalala"}])
 
 
 def suite():

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -419,7 +419,7 @@ class XRImage(object):
         return delay
 
     @delayed(nout=1, pure=True)
-    def _delayed_apply_pil(self, fun, pil_args, pil_kwargs, fun_args, fun_kwargs):
+    def _delayed_apply_pil(self, fun, pil_args, pil_kwargs, fun_args, fun_kwargs, output_mode=None):
         if pil_args is None:
             pil_args = tuple()
         if pil_kwargs is None:
@@ -429,6 +429,8 @@ class XRImage(object):
         if fun_kwargs is None:
             fun_kwargs = dict()
         new_img = fun(self.pil_image(*pil_args, **pil_kwargs), *fun_args, **fun_kwargs)
+        if output_mode is not None:
+            new_img = new_img.convert(output_mode)
         return np.array(new_img) / self.data.dtype.type(255.0)
 
     def apply_pil(self, fun, output_mode, pil_args, pil_kwargs, fun_args, fun_kwargs):
@@ -441,7 +443,7 @@ class XRImage(object):
         The pil_args and pil_kwargs are passed the the `pil_image` method the XRImage instance.
 
         """
-        new_array = self._delayed_apply_pil(fun, pil_args, pil_kwargs, fun_args, fun_kwargs)
+        new_array = self._delayed_apply_pil(fun, pil_args, pil_kwargs, fun_args, fun_kwargs, output_mode)
         bands = len(output_mode)
         arr = da.from_delayed(new_array, dtype=self.data.dtype,
                               shape=(self.data.sizes['y'], self.data.sizes['x'], bands))

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -433,7 +433,7 @@ class XRImage(object):
             new_img = new_img.convert(output_mode)
         return np.array(new_img) / self.data.dtype.type(255.0)
 
-    def apply_pil(self, fun, output_mode, pil_args, pil_kwargs, fun_args, fun_kwargs):
+    def apply_pil(self, fun, output_mode, pil_args=None, pil_kwargs=None, fun_args=None, fun_kwargs=None):
         """Apply a function `fun` on the pillow image corresponding to the instance of the XRImage.
 
         The function shall take a pil image as first argument, and is then passed fun_args and fun_kwargs.

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -419,7 +419,8 @@ class XRImage(object):
         return delay
 
     @delayed(nout=1, pure=True)
-    def _delayed_apply_pil(self, fun, pil_args, pil_kwargs, fun_args, fun_kwargs, image_mda=None, output_mode=None):
+    def _delayed_apply_pil(self, fun, pil_args, pil_kwargs, fun_args, fun_kwargs,
+                           image_metadata=None, output_mode=None):
         if pil_args is None:
             pil_args = tuple()
         if pil_kwargs is None:
@@ -428,9 +429,9 @@ class XRImage(object):
             fun_args = tuple()
         if fun_kwargs is None:
             fun_kwargs = dict()
-        if image_mda is None:
-            image_mda = dict()
-        new_img = fun(self.pil_image(*pil_args, **pil_kwargs), *fun_args, image_mda=image_mda, **fun_kwargs)
+        if image_metadata is None:
+            image_metadata = dict()
+        new_img = fun(self.pil_image(*pil_args, **pil_kwargs), image_metadata, *fun_args, **fun_kwargs)
         if output_mode is not None:
             new_img = new_img.convert(output_mode)
         return np.array(new_img) / self.data.dtype.type(255.0)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -440,7 +440,7 @@ class XRImage(object):
         It is expected to return the modified pil image.
         This function returns a new XRImage instance with the modified image data.
 
-        The pil_args and pil_kwargs are passed the the `pil_image` method the XRImage instance.
+        The pil_args and pil_kwargs are passed to the `pil_image` method of the XRImage instance.
 
         """
         new_array = self._delayed_apply_pil(fun, pil_args, pil_kwargs, fun_args, fun_kwargs, output_mode)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -659,6 +659,13 @@ class XRImage(object):
                       DeprecationWarning)
         return self.finalize(fill_value, dtype, keep_palette, cmap)
 
+    def final_mode(self, fill_value=None):
+        """Get the mode of the finalized image when provided this fill_value."""
+        if fill_value is None and not self.mode.endswith('A'):
+            return self.mode + 'A'
+        else:
+            return self.mode
+
     def finalize(self, fill_value=None, dtype=np.uint8, keep_palette=False, cmap=None):
         """Finalize the image to be written to an output file.
 


### PR DESCRIPTION
This new method delays the processing with a dask delayed object.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
