### PR TITLE
Add scale and offset inclusion utility when rio saving

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1227,16 +1227,16 @@ class TestXRImage(unittest.TestCase):
         from trollimage import xrimage
         import rasterio as rio
 
-        data = xr.DataArray(np.arange(75).reshape(5, 5, 3), dims=[
-            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
-        img = xrimage.XRImage(data / 75.0)
-        img.data.attrs['enhancement_history'] = [{'scale': 1.0 / 75, 'offset': 0}]
+        data = xr.DataArray(np.arange(25).reshape(5, 5, 1), dims=[
+            'y', 'x', 'bands'], coords={'bands': ['L']})
+        img = xrimage.XRImage(data)
+        img.stretch()
         with NamedTemporaryFile(suffix='.tif') as tmp:
             img.save(tmp.name, include_scale_offset_tags=True)
-            tags = {'scale': 75.0 / 255, 'offset': 0}
+            tags = {'scale': 24.0 / 255, 'offset': 0}
             with rio.open(tmp.name) as f:
+                ftags = f.tags()
                 for key, val in tags.items():
-                    ftags = f.tags()
                     self.assertAlmostEqual(float(ftags[key]), val)
 
     def test_gamma(self):

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -855,7 +855,7 @@ class XRImage(object):
 
         final_data = self.data.copy()
         try:
-            final_data.attrs['enhancement_history'] = self.data.attrs['enhancement_history'].copy()
+            final_data.attrs['enhancement_history'] = list(self.data.attrs['enhancement_history'])
         except KeyError:
             pass
         attrs = final_data.attrs

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -858,6 +858,7 @@ class XRImage(object):
             final_data.attrs['enhancement_history'] = self.data.attrs['enhancement_history'].copy()
         except KeyError:
             pass
+        attrs = final_data.attrs
         # if the data are integers then this fill value will be used to check for invalid values
         with xr.set_options(keep_attrs=True):
             ifill = final_data.attrs.get('_FillValue') if np.issubdtype(final_data, np.integer) else None
@@ -885,8 +886,9 @@ class XRImage(object):
                     elif fill_value is not None:
                         final_data = final_data.fillna(dtype(fill_value))
 
-                    final_data = final_data.astype(dtype)
-                    final_data.attrs = attrs
+            final_data = final_data.astype(dtype)
+            final_data.attrs = attrs
+
         return final_data, ''.join(final_data['bands'].values)
 
     def pil_image(self, fill_value=None, compute=True):

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -409,7 +409,7 @@ class XRImage(object):
                 help retrieving original data values from pixel values.
 
         Returns:
-            The delayed or computed resulf of the saving.
+            The delayed or computed result of the saving.
 
         """
         fformat = fformat or os.path.splitext(filename)[1][1:]

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -854,7 +854,10 @@ class XRImage(object):
             fill_value = 0
 
         final_data = self.data.copy()
-        final_data.attrs['enhancement_history'] = self.data.attrs['enhancement_history'].copy()
+        try:
+            final_data.attrs['enhancement_history'] = self.data.attrs['enhancement_history'].copy()
+        except KeyError:
+            pass
         # if the data are integers then this fill value will be used to check for invalid values
         with xr.set_options(keep_attrs=True):
             ifill = final_data.attrs.get('_FillValue') if np.issubdtype(final_data, np.integer) else None


### PR DESCRIPTION
This PR allows the inclusion of scale and offset tags in a file saved with rasterio.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
