### PR TITLE
Fix XRImage producing read-only data arrays and switch to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='pillow gdal xarray dask toolz mock coverage coveralls codecov rasterio pytest pytest-cov'
+        - CONDA_DEPENDENCIES='pillow gdal xarray dask toolz coverage coveralls codecov rasterio pytest pytest-cov'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='pillow gdal xarray dask toolz coverage coveralls codecov rasterio pytest pytest-cov'
+        - CONDA_DEPENDENCIES='pillow gdal xarray dask coverage coveralls codecov rasterio pytest pytest-cov'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,30 +5,50 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='pillow gdal xarray dask toolz mock coverage coveralls codecov rasterio'
+        - CONDA_DEPENDENCIES='pillow gdal xarray dask toolz mock coverage coveralls codecov rasterio pytest pytest-cov'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='conda-forge'
         - CONDA_CHANNEL_PRIORITY=True
+        - UNSTABLE_DEPS=False
 
 matrix:
   include:
-  - env:
-    - PYTHON_VERSION=2.7
-    - NUMPY_VERSION=1.16
-    os: linux
-  - env: PYTHON_VERSION=3.6
-    os: linux
   - env: PYTHON_VERSION=3.7
     os: linux
+  - env: PYTHON_VERSION=3.8
+    os: linux
+  - env:
+    - PYTHON_VERSION=3.8
+    - UNSTABLE_DEPS=True
+    os: linux
+  allow_failures:
+    - env:
+        - PYTHON_VERSION=3.8
+        - UNSTABLE_DEPS=True
+      os: linux
 
 install:
-    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda.sh
-script: coverage run --source=trollimage setup.py test
+  - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+  - source ci-helpers/travis/setup_conda.sh
+  - if [ "$UNSTABLE_DEPS" == "True" ]; then
+    python -m pip install
+    -f https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com
+    --no-deps --pre --upgrade
+    numpy
+    pandas;
+    python -m pip install
+    --no-deps --upgrade
+    git+https://github.com/dask/dask
+    git+https://github.com/mapbox/rasterio
+    git+https://github.com/pydata/xarray;
+    fi
+  - pip install -e . --no-deps
+script:
+  - pytest --cov=trollimage trollimage/tests
 after_success:
-    - if [[ $PYTHON_VERSION == 3.6 ]]; then coveralls; fi
+  - if [[ $PYTHON_VERSION == 3.8 ]]; then coveralls; fi
 deploy:
   - provider: pypi
     user: dhoese

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "pillow gdal xarray dask toolz mock coverage coveralls codecov rasterio pytest pytest-cov"
+    CONDA_DEPENDENCIES: "pillow gdal xarray dask coverage coveralls codecov rasterio pytest pytest-cov"
     CONDA_CHANNELS: "conda-forge"
     CONDA_CHANNEL_PRIORITY: "True"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,23 +3,18 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "pillow gdal xarray dask toolz mock coverage coveralls codecov rasterio"
+    CONDA_DEPENDENCIES: "pillow gdal xarray dask toolz mock coverage coveralls codecov rasterio pytest pytest-cov"
     CONDA_CHANNELS: "conda-forge"
     CONDA_CHANNEL_PRIORITY: "True"
 
   matrix:
-    - PYTHON: "C:\\Python27_64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      NUMPY_VERSION: "stable"
-
-    - PYTHON: "C:\\Python36_64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-      NUMPY_VERSION: "stable"
-
     - PYTHON: "C:\\Python37_64"
       PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "64"
+      NUMPY_VERSION: "stable"
+
+    - PYTHON: "C:\\Python38_64"
+      PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "stable"
 
@@ -27,11 +22,12 @@ install:
     - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "conda activate test"
+    - "pip install -e ."
 
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  - "%CMD_IN_ENV% python setup.py test"
+  - "%CMD_IN_ENV% pytest --cov=trollimage trollimage/tests"
 
 after_test:
   # If tests are successful, create a whl package for the project.

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,5 +1,4 @@
 pillow
-six
 rasterio
 xarray
 dask[array]

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ setup(name="trollimage",
       url="https://github.com/pytroll/trollimage",
       packages=['trollimage'],
       zip_safe=False,
-      install_requires=['numpy >=1.13', 'pillow', 'six'],
+      install_requires=['numpy >=1.13', 'pillow'],
+      python_requires='>=3.6',
       extras_require={
           'geotiff': ['rasterio'],
           'xarray': ['xarray', 'dask[array]'],
       },
-      test_suite='trollimage.tests.suite',
       )

--- a/trollimage/image.py
+++ b/trollimage/image.py
@@ -33,7 +33,6 @@ import re
 from copy import deepcopy
 
 import numpy as np
-import six
 from PIL import Image as Pil
 
 try:
@@ -377,7 +376,7 @@ class Image(object):
         if self.is_empty():
             raise IOError("Cannot save an empty image")
 
-        if isinstance(filename, (str, six.text_type)):
+        if isinstance(filename, str):
             ensure_dir(filename)
 
         fformat = fformat or os.path.splitext(filename)[1][1:4]

--- a/trollimage/tests/__init__.py
+++ b/trollimage/tests/__init__.py
@@ -19,33 +19,4 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-"""The tests package.
-"""
-
-from trollimage import image, colormap
-from trollimage.tests import test_image, test_colormap
-import unittest
-import doctest
-
-
-def suite():
-    """The global test suite.
-    """
-    mysuite = unittest.TestSuite()
-    # Test the documentation strings
-    mysuite.addTests(doctest.DocTestSuite(image))
-    # Use the unittests also
-    mysuite.addTests(test_image.suite())
-
-    mysuite.addTests(doctest.DocTestSuite(colormap))
-    mysuite.addTests(test_colormap.suite())
-    
-    return mysuite
-
-
-def load_tests(loader, tests, pattern):
-    return suite()
-
-if __name__ == '__main__':
-    unittest.TextTestRunner(verbosity=2).run(suite())
+"""The tests package."""

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -19,9 +19,7 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-"""Test colormap.py
-"""
+"""Test colormap.py."""
 
 import unittest
 from trollimage import colormap
@@ -173,13 +171,3 @@ class TestColormapClass(unittest.TestCase):
                3: (255, 255, 255), 4: (0, 0, 0)}
 
         self.assertEqual(d, exp)
-
-
-def suite():
-    """The suite for test_colormap.
-    """
-    loader = unittest.TestLoader()
-    mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestColormapClass))
-
-    return mysuite

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -27,17 +27,12 @@ import random
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
 import numpy as np
-
 from trollimage import image
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 EPSILON = 0.0001
 
@@ -1979,21 +1974,3 @@ class TestXRImage(unittest.TestCase):
         self.assertEqual(dummy_args, [({}, ), {}])
         res.data.data.compute()
         self.assertEqual(dummy_args, [(OrderedDict(), 'Hey', 'Jude'), {'chorus': "La lala lalalala"}])
-
-
-def suite():
-    """Create the suite for test_image."""
-    loader = unittest.TestLoader()
-    mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestEmptyImage))
-    mysuite.addTest(loader.loadTestsFromTestCase(TestImageCreation))
-    mysuite.addTest(loader.loadTestsFromTestCase(TestRegularImage))
-    mysuite.addTest(loader.loadTestsFromTestCase(TestFlatImage))
-    mysuite.addTest(loader.loadTestsFromTestCase(TestNoDataImage))
-    mysuite.addTest(loader.loadTestsFromTestCase(TestXRImage))
-
-    return mysuite
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -755,6 +755,22 @@ class TestXRImage(unittest.TestCase):
         img = xrimage.XRImage(data)
         self.assertEqual(img.mode, 'YCbCrA')
 
+    def test_init_writability(self):
+        """Test data is writable after init.
+
+        Xarray >0.15 makes data read-only after expand_dims.
+
+        """
+        import xarray as xr
+        import numpy as np
+        from trollimage import xrimage
+        data = xr.DataArray([[0, 0.5, 0.5], [0.5, 0.25, 0.25]], dims=['y', 'x'])
+        img = xrimage.XRImage(data)
+        self.assertEqual(img.mode, 'L')
+        n_arr = np.asarray(img.data)
+        # if this succeeds then its writable
+        n_arr[n_arr == 0.5] = 1
+
     def test_regression_double_format_save(self):
         """Test that double format information isn't passed to save."""
         import xarray as xr

--- a/trollimage/utilities.py
+++ b/trollimage/utilities.py
@@ -1,21 +1,11 @@
+"""Simple utilities functions to handle colormaps and other use cases."""
+
 from __future__ import division
-import matplotlib.pyplot as plt
 import numpy as np
-import numpy.ma as ma
-import pickle
-import matplotlib.cm as cm
-import matplotlib as mpl
 import sys
-from scipy import misc
-from trollimage.colormap import rdbu, spectral, greys, Colormap
+from trollimage.colormap import Colormap
 from trollimage.image import Image
 from PIL import Image as Pimage
-import matplotlib.colors as mcolors
-import matplotlib
-
-"""Some simple utilities functions to handle colormaps
-and to convert PIL image to GeoImage.
-"""
 
 def _hex_to_rgb(value):
     '''

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -294,10 +294,6 @@ class XRImage(object):
         if not hasattr(data, 'dims'):
             raise TypeError("Data must have a 'dims' attribute.")
 
-        # doesn't actually copy the data underneath
-        # we don't want our operations to change the user's data
-        data = data.copy()
-
         if 'y' not in data.dims or 'x' not in data.dims:
             if data.ndim != 2:
                 raise ValueError("Data must have a 'y' and 'x' dimension")
@@ -319,6 +315,11 @@ class XRImage(object):
                 data['bands'] = ['L']
             else:
                 raise ValueError("No 'bands' dimension provided.")
+
+        # doesn't actually copy the data underneath
+        # we don't want our operations to change the user's data
+        # we do this last in case `expand_dims` made the data read only
+        data = data.copy()
 
         return data
 


### PR DESCRIPTION
I know this is a lot for one PR but the bug that I'm actually fixing is only an issue with the dev version of xarray so I needed to rework the travis config anyway. So I used the opportunity to update tests to use pytest.

This "bug" is due to a recent change in xarray's `expand_dims` producing read-only arrays: https://github.com/pydata/xarray/issues/3813

This is showing up in https://github.com/pytroll/satpy/pull/1095 for one of the enhancement tests in Satpy.

 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
