### PR TITLE
Add long description for display by PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,14 @@
 from setuptools import setup
 import versioneer
 
+with open('README.rst', 'r') as readme_file:
+    long_description = readme_file.read()
+
 setup(name="trollimage",
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       description='Pytroll imaging library',
+      long_description=long_description,
       author='Martin Raspaud',
       author_email='martin.raspaud@smhi.se',
       classifiers=["Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
There needs to be a `long_description` set in the setup.py to provide PyPI with the content to show on the PyPI project page.

This doesn't really deserve it's own release, but can be included whenever another release goes out.