### PR TITLE
Add more helpful error message when saving JPEG with alpha band

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -808,6 +808,10 @@ class TestXRImage(unittest.TestCase):
         img = xrimage.XRImage(data)
         with NamedTemporaryFile(suffix='.jpg') as tmp:
             img.save(tmp.name, fill_value=0)
+        # Jpeg fails without fill value (no alpha handling)
+        with NamedTemporaryFile(suffix='.jpg') as tmp:
+            # make sure fill_value is mentioned in the error message
+            self.assertRaisesRegex(OSError, "fill_value", img.save, tmp.name)
         # As PNG that support alpha channel
         img = xrimage.XRImage(data)
         with NamedTemporaryFile(suffix='.png') as tmp:


### PR DESCRIPTION
Satpy users often complain or are confused by an error message like "cannot write mode LA as JPEG" or "cannot write mode RGBA as JPEG". This is because by default we add an alpha band in trollimage and JPEG doesn't support alpha bands. This PR catches an exception and prints a more useful error message.

Alternative solution: Hardcode that "JPEG" format can't support transparency (any other formats) and set a default `fill_value=0` for these case *if* the data doesn't already have an alpha band. For example, if the user provided an RGBA composite then we don't want to remove the Alpha since it could mean something. In this case we should still provide this new error message.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
