### PR TITLE
Add option for geotiff overview resampling and auto-levels

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -251,4 +251,5 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'xarray': ('https://xarray.pydata.org/en/stable', None),
     'dask': ('https://dask.pydata.org/en/latest', None),
+    'rasterio': ('https://rasterio.readthedocs.io/en/latest', None),
 }

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1216,6 +1216,30 @@ class TestXRImage(unittest.TestCase):
             with rio.open(tmp.name) as f:
                 self.assertEqual(len(f.overviews(1)), 2)
 
+        # auto-levels
+        data = np.zeros(25*25*3, dtype=np.uint8).reshape(25, 25, 3)
+        data = xr.DataArray(data, dims=[
+            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+        img = xrimage.XRImage(data)
+        self.assertTrue(np.issubdtype(img.data.dtype, np.integer))
+        with NamedTemporaryFile(suffix='.tif') as tmp:
+            img.save(tmp.name, overviews=[], overviews_minsize=2)
+            with rio.open(tmp.name) as f:
+                self.assertEqual(len(f.overviews(1)), 4)
+
+        # auto-levels and resampling
+        data = np.zeros(25*25*3, dtype=np.uint8).reshape(25, 25, 3)
+        data = xr.DataArray(data, dims=[
+            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+        img = xrimage.XRImage(data)
+        self.assertTrue(np.issubdtype(img.data.dtype, np.integer))
+        with NamedTemporaryFile(suffix='.tif') as tmp:
+            img.save(tmp.name, overviews=[], overviews_minsize=2,
+                     overviews_resampling='average')
+            with rio.open(tmp.name) as f:
+                # no way to check resampling method from the file
+                self.assertEqual(len(f.overviews(1)), 4)
+
     @unittest.skipIf(sys.platform.startswith('win'), "'NamedTemporaryFile' not supported on Windows")
     def test_save_tags(self):
         """Test saving geotiffs with tags."""

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -206,7 +206,6 @@ class RIODataset:
 
     def close(self):
         """Close the file."""
-        print("Closing: ", self.overviews, self.overviews_resampling, self.overviews_minsize)
         if self.overviews is not None:
             overviews = self.overviews
             # it's an empty list
@@ -576,7 +575,6 @@ class XRImage(object):
                 continue
 
         r_file.rfile.update_tags(**tags)
-        print(overviews)
         r_dataset = RIODataset(r_file, overviews,
                                overviews_resampling=overviews_resampling,
                                overviews_minsize=overviews_minsize)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -428,7 +428,7 @@ class XRImage(object):
     def rio_save(self, filename, fformat=None, fill_value=None,
                  dtype=np.uint8, compute=True, tags=None,
                  keep_palette=False, cmap=None, overviews=None,
-                 overviews_resampling=None, overviews_minsize=256,
+                 overviews_minsize=256, overviews_resampling=None,
                  include_scale_offset_tags=False,
                  **format_kwargs):
         """Save the image using rasterio.

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -209,8 +209,8 @@ class RIODataset:
         print("Closing: ", self.overviews, self.overviews_resampling, self.overviews_minsize)
         if self.overviews is not None:
             overviews = self.overviews
-            # it's an empty list or tuple
-            if len(overviews) == 0 or overviews == 'auto':
+            # it's an empty list
+            if len(overviews) == 0:
                 from rasterio.rio.overview import get_maximum_overview_level
                 width = self.rfile.width
                 height = self.rfile.height


### PR DESCRIPTION
This adds an `overviews_resampling` option which can be set to other GDAL overview resampling methods (ex. `average` or `nearest`). This also adds the calculation of overview levels if not provided. This is enabled by specifying overview levels as an empty list.

 - [x] Closes #61  (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

Side note: I notice that XRImage isn't in the API docs. Do we want that fixed?