### PR TITLE
Add workaround for broken aggdraw.Font usage in satpy/pycoast

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1984,21 +1984,23 @@ class TestXRImage(unittest.TestCase):
             return pil_obj
 
         img = xrimage.XRImage(data)
-        pi = mock.MagicMock()
-        img.pil_image = pi
-        res = img.apply_pil(dummy_fun, 'RGB')
-        # check that the pil image generation is delayed
-        pi.assert_not_called()
-        # make it happen
-        res.data.data.compute()
-        pi.return_value.convert.assert_called_with('RGB')
+        with mock.patch.object(xrimage, "PILImage") as pi:
+            pil_img = mock.MagicMock()
+            pi.fromarray = mock.Mock(wraps=lambda *args, **kwargs: pil_img)
+            res = img.apply_pil(dummy_fun, 'RGB')
+            # check that the pil image generation is delayed
+            pi.fromarray.assert_not_called()
+            # make it happen
+            res.data.data.compute()
+            pil_img.convert.assert_called_with('RGB')
 
         img = xrimage.XRImage(data)
-        pi = mock.MagicMock()
-        img.pil_image = pi
-        res = img.apply_pil(dummy_fun, 'RGB',
-                            fun_args=('Hey', 'Jude'),
-                            fun_kwargs={'chorus': "La lala lalalala"})
-        self.assertEqual(dummy_args, [({}, ), {}])
-        res.data.data.compute()
-        self.assertEqual(dummy_args, [(OrderedDict(), 'Hey', 'Jude'), {'chorus': "La lala lalalala"}])
+        with mock.patch.object(xrimage, "PILImage") as pi:
+            pil_img = mock.MagicMock()
+            pi.fromarray = mock.Mock(wraps=lambda *args, **kwargs: pil_img)
+            res = img.apply_pil(dummy_fun, 'RGB',
+                                fun_args=('Hey', 'Jude'),
+                                fun_kwargs={'chorus': "La lala lalalala"})
+            self.assertEqual(dummy_args, [({}, ), {}])
+            res.data.data.compute()
+            self.assertEqual(dummy_args, [(OrderedDict(), 'Hey', 'Jude'), {'chorus': "La lala lalalala"}])

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2004,3 +2004,22 @@ class TestXRImage(unittest.TestCase):
             self.assertEqual(dummy_args, [({}, ), {}])
             res.data.data.compute()
             self.assertEqual(dummy_args, [(OrderedDict(), 'Hey', 'Jude'), {'chorus': "La lala lalalala"}])
+
+        # Test HACK for _burn_overlay
+        dummy_args = [(OrderedDict(), ), {}]
+
+        def _burn_overlay(pil_obj, *args, **kwargs):
+            dummy_args[0] = args
+            dummy_args[1] = kwargs
+            return pil_obj
+
+        img = xrimage.XRImage(data)
+        with mock.patch.object(xrimage, "PILImage") as pi:
+            pil_img = mock.MagicMock()
+            pi.fromarray = mock.Mock(wraps=lambda *args, **kwargs: pil_img)
+            res = img.apply_pil(_burn_overlay, 'RGB')
+            # check that the pil image generation is delayed
+            pi.fromarray.assert_not_called()
+            # make it happen
+            res.data.data.compute()
+            pil_img.convert.assert_called_with('RGB')

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -679,9 +679,11 @@ class XRImage(object):
                 fun_args = tuple()
             if fun_kwargs is None:
                 fun_kwargs = dict()
+            tokenize_args = (fun, pil_image, fun_args[:-1], fun_kwargs,
+                             self.data.attrs, output_mode)
             dask_key_name = "%s-%s" % (
                 funcname(func),
-                tokenize(func.key, *(fun, pil_image, fun_args[:-1], fun_kwargs, self.data.attrs, output_mode), pure=True),
+                tokenize(func.key, *tokenize_args, pure=True),
             )
             delayed_kwargs['dask_key_name'] = dask_key_name
 


### PR DESCRIPTION
This addresses the https://github.com/pytroll/pycoast/issues/43 issue. In summary, Satpy tried to delay calls to pycoast by using the `apply_pil` method on trollimage's XRImage class. In some use cases this could involve passing an aggdraw `Font` object to the dask Delayed function. As part of the tokenization of the arguments dask calls `type(obj)` on the `Font` object which causes a segmentation fault because aggdraw.Font objects are not normal python types.

The solution in this PR is a complete hack, but works. The long term solution is to fix aggdraws classes but that is a *huge* problem to solve. Another solution would be to update pycoast to pass the individual components of a font (path, color, size, opacity) but that is also a pretty huge task (easier than aggdraw) if it is done right. This solution, essentially an if statement, should be removed when a better version of aggdraw is available.

 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)

CC @peters77