### PR TITLE
Fix tiff tag writing if start_time is None

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1006,16 +1006,7 @@ class TestXRImage(unittest.TestCase):
     def test_save_geotiff_datetime(self):
         """Test saving geotiffs when start_time is in the attributes."""
         import xarray as xr
-        from trollimage import xrimage
-        import rasterio as rio
         import datetime as dt
-
-        def _get_tags_after_writing_to_geotiff(data):
-            img = xrimage.XRImage(data)
-            with NamedTemporaryFile(suffix='.tif') as tmp:
-                img.save(tmp.name)
-                with rio.open(tmp.name) as f:
-                    return f.tags()
 
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3), dims=[
             'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
@@ -2062,3 +2053,14 @@ class TestXRImage(unittest.TestCase):
             # make it happen
             res.data.data.compute()
             pil_img.convert.assert_called_with('RGB')
+
+
+def _get_tags_after_writing_to_geotiff(data):
+    from trollimage import xrimage
+    import rasterio as rio
+
+    img = xrimage.XRImage(data)
+    with NamedTemporaryFile(suffix='.tif') as tmp:
+        img.save(tmp.name)
+        with rio.open(tmp.name) as f:
+            return f.tags()

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -529,11 +529,10 @@ class XRImage(object):
                 except KeyError:
                     logger.info("Couldn't create geotransform")
 
-            if "start_time" in data.attrs:
-                stime = data.attrs['start_time']
-                if stime:
-                    stime_str = stime.strftime("%Y:%m:%d %H:%M:%S")
-                    tags.setdefault('TIFFTAG_DATETIME', stime_str)
+            stime = data.attrs.get("start_time")
+            if stime:
+                stime_str = stime.strftime("%Y:%m:%d %H:%M:%S")
+                tags.setdefault('TIFFTAG_DATETIME', stime_str)
         elif driver == 'JPEG' and 'A' in mode:
             raise ValueError('JPEG does not support alpha')
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -531,8 +531,9 @@ class XRImage(object):
 
             if "start_time" in data.attrs:
                 stime = data.attrs['start_time']
-                stime_str = stime.strftime("%Y:%m:%d %H:%M:%S")
-                tags.setdefault('TIFFTAG_DATETIME', stime_str)
+                if stime:
+                    stime_str = stime.strftime("%Y:%m:%d %H:%M:%S")
+                    tags.setdefault('TIFFTAG_DATETIME', stime_str)
         elif driver == 'JPEG' and 'A' in mode:
             raise ValueError('JPEG does not support alpha')
 


### PR DESCRIPTION
This PR fixes tiff tag writing in case where the attributes have `start_time` of `None`. This can happen in Satpy when data are read with `reader='generic_image'` and the filename doesn't have a valid date in it.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
