### PR TITLE
Change XRImage.save to keep fill_value separate from valid data

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -898,7 +898,6 @@ class TestXRImage:
             # all other pixels should be opaque
             assert file_data[1, 0, 0] == 255
 
-
     @pytest.mark.skipif(sys.platform.startswith('win'),
                         reason="'NamedTemporaryFile' not supported on Windows")
     def test_save_palettes(self):

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -785,17 +785,9 @@ class TestXRImage:
     def test_rgb_save(self):
         """Test saving RGB/A data to simple image formats."""
         import xarray as xr
-        import dask.array as da
         from dask.delayed import Delayed
         from trollimage import xrimage
-        from trollimage.colormap import brbg, Colormap
         import rasterio as rio
-
-        # RGBA colormap
-        bw = Colormap(
-            (0.0, (1.0, 1.0, 1.0, 1.0)),
-            (1.0, (0.0, 0.0, 0.0, 0.5)),
-        )
 
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3) / 74., dims=[
             'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
@@ -1696,7 +1688,7 @@ class TestXRImage:
             img = img.convert('LA')
             assert np.issubdtype(img.data.dtype, np.integer)
             assert img.mode == 'LA'
-            assert len(img.data.coords['bands'] == 2)
+            assert len(img.data.coords['bands']) == 2
             # make sure the alpha band is all opaque except the first pixel
             alpha = img.data.sel(bands='A').values.ravel()
             np.testing.assert_allclose(alpha[0], 0)

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -758,7 +758,6 @@ class TestXRImage:
 
         """
         import xarray as xr
-        import numpy as np
         from trollimage import xrimage
         data = xr.DataArray([[0, 0.5, 0.5], [0.5, 0.25, 0.25]], dims=['y', 'x'])
         img = xrimage.XRImage(data)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -990,7 +990,7 @@ class XRImage(object):
                 is then scaled to fit the remainder of the data type space.
                 Integer image data will **not** be scaled. For example, a
                 ``dtype`` of ``numpy.uint8`` and a ``fill_value`` of 0 will
-                result in data being scaled linearly from 1 to 255.
+                result in floating-point data being scaled linearly from 1 to 255.
             dtype (numpy.dtype): Output data type to convert the current image
                 data to. Default is unsigned 8-bit integer
                 (:class:`numpy.uint8`).

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -35,6 +35,7 @@ chunks can be saved in parallel.
 import logging
 import os
 import threading
+import warnings
 from contextlib import suppress
 
 import dask
@@ -772,7 +773,7 @@ class XRImage(object):
         data.attrs = attrs
         return data
 
-    def _scale_to_dtype(self, data, dtype):
+    def _scale_to_dtype(self, data, dtype, fill_value=None):
         """Scale provided data to dtype range assuming a 0-1 range.
 
         Float input data is assumed to be normalized to a 0 to 1 range.
@@ -788,9 +789,24 @@ class XRImage(object):
                 data = data.clip(np.iinfo(dtype).min, np.iinfo(dtype).max)
             else:
                 # scale float data (assumed to be 0 to 1) to full integer space
+                # leave room for fill value if needed
                 dinfo = np.iinfo(dtype)
                 scale = dinfo.max - dinfo.min
                 offset = dinfo.min
+                if fill_value is not None:
+                    if fill_value == dinfo.min:
+                        # leave the lowest value for fill value only
+                        offset = offset + 1
+                        scale = scale - 1
+                    elif fill_value == dinfo.max:
+                        # leave the top value for fill value only
+                        scale = scale - 1
+                    else:
+                        warnings.warn(
+                            "Specified fill value will overlap with valid "
+                            "data. To avoid this warning specify a fill_value "
+                            "that is the minimum or maximum for the data type "
+                            "being saved to.")
                 data = data.clip(0, 1) * scale + offset
                 attrs.setdefault('enhancement_history', list()).append({'scale': scale, 'offset': offset})
             data = data.round()
@@ -933,7 +949,7 @@ class XRImage(object):
     def _scale_and_replace_fill_value(self, data, input_fill_value, fill_value, dtype):
         # scale float data to the proper dtype
         # this method doesn't cast yet so that we can keep track of NULL values
-        data = self._scale_to_dtype(data, dtype)
+        data = self._scale_to_dtype(data, dtype, fill_value)
         data = self._replace_fill_value(data, input_fill_value, fill_value, dtype)
         return data
 
@@ -965,6 +981,12 @@ class XRImage(object):
                 otherwise. Some output formats do not support alpha channels
                 so a ``fill_value`` must be provided. This is determined by
                 the underlying library doing the writing (pillow or rasterio).
+                If specified, it must be the minimum or maximum of the
+                ``dtype`` (ex. 0 or 255 for uint8). Floating point image data
+                is then scaled to fit the remainder of the data type space.
+                Integer image data will **not** be scaled. For example, a
+                ``dtype`` of ``numpy.uint8`` and a ``fill_value`` of 0 will
+                result in data being scaled linearly from 1 to 255.
             dtype (numpy.dtype): Output data type to convert the current image
                 data to. Default is unsigned 8-bit integer
                 (:class:`numpy.uint8`).

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -981,7 +981,7 @@ class XRImage(object):
                 otherwise. Some output formats do not support alpha channels
                 so a ``fill_value`` must be provided. This is determined by
                 the underlying library doing the writing (pillow or rasterio).
-                If specified, it must be the minimum or maximum of the
+                If specified, it should be the minimum or maximum of the
                 ``dtype`` (ex. 0 or 255 for uint8). Floating point image data
                 is then scaled to fit the remainder of the data type space.
                 Integer image data will **not** be scaled. For example, a


### PR DESCRIPTION
This PR is a big change in the sense that it changes the output of any XRImage save that passes a `fill_value`. The main problem I'm trying to avoid here is having a single output/image value that represents both invalid and valid data. Take for example this fake XRImage data that we would like to save:

```
[[0.5, 0.5, 0.5, 0.5, 0.5],
 [0.5, 0.5, 0.5, 0.5, 0.5],
 [0.0, 0.0, 0.0, 0.0, np.nan],
 [0.5, 0.5, 0.5, 0.5, 0.5],
 [0.5, 0.5, 0.5, 0.5, 0.5]]
```

In this data, `np.nan` is used to mark a pixel as invalid and is what xarray will do by default. Now with the current master branch version of trollimage if I did `my_xrimg.save("test.png", fill_value=0)`, my resulting image would contain:

```
[[128, 128, 128, 128, 128],
 [128, 128, 128, 128, 128],
 [  0,   0,   0,   0,   0],
 [128, 128, 128, 128, 128],
 [128, 128, 128, 128, 128]]
```

With this PR you would get:

```
[[129, 129, 129, 129, 129],
 [129, 129, 129, 129, 129],
 [  1,   1,   1,   1,   0],
 [129, 129, 129, 129, 129],
 [129, 129, 129, 129, 129]]
```

In the master branch version we can't tell the difference between valid and invalid data. In this PR's version there is an explicit offset so valid data will never equal the value used for invalid data.

Note:

1. This PR only does this for float data being saved to integers. Integer input data (think category data) is not changed.
2. This PR only does this behavior for a `fill_value` that is the minimum or maximum of the data type that is being saved to. So in the default uint8 case a fill_value of 0 and 255 will be unique fill values. Anything else produces a warning that the valid and invalid data overlap.

I technically documented this in the save docstring but feel it should probably be mentioned somewhere else, but I'm not sure where. Additionally this PR does **not** modify the regular numpy Image class.

I'm realizing that one major downside to this might be if someone specifically enhanced/stretched their data and then expected to undo that scaling on the resulting image data, they would get different results.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
