### PR TITLE
Remove defaults channel from ci conda environment and strict priority

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,8 @@ jobs:
           miniconda-version: "latest"
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
-          channels: conda-forge,defaults
+          channels: conda-forge
+          channel-priority: strict
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -745,7 +745,9 @@ class XRImage(object):
         null_mask = null_mask.any(dim='bands')
         null_mask = null_mask.expand_dims('bands')
         null_mask['bands'] = ['A']
-        # match data dtype
+        # changes to null_mask attrs should not effect the original attrs
+        # XRImage never uses them either
+        null_mask.attrs = {}
         return null_mask
 
     def _add_alpha(self, data, alpha=None):


### PR DESCRIPTION
Github is producing some warnings. This tries to get rid of them while also investigating a failure on Ubuntu that only showed up in master.