### PR TITLE
Fix list stretch tags

### DIFF
--- a/doc/colormap.rst
+++ b/doc/colormap.rst
@@ -11,10 +11,10 @@ A simple example of applying a colormap on data::
     from trollimage.image import Image
 
     img = Image(data, mode="L")
-    
+
     rdbu.set_range(-90 + 273.15, 30 + 273.15)
     img.colorize(rdbu)
-    
+
     img.show()
 
 .. image:: _static/hayan_simple.png
@@ -29,7 +29,7 @@ A more complex example, with a colormap build from greyscale on one end, and spe
     from trollimage.image import Image
 
     img = Image(data, mode="L")
-    
+
     greys.set_range(-40 + 273.15, 30 + 273.15)
     spectral.set_range(-90 + 273.15, -40.00001 + 273.15)
     my_cm = spectral + greys
@@ -46,10 +46,10 @@ Now applying a palette to the data, with sharp edges::
     from trollimage.image import Image
 
     img = Image(data, mode="L")
-    
+
     set3.set_range(-90 + 273.15, 30 + 273.15)
     img.palettize(set3)
-    
+
     img.show()
 
 .. image:: _static/phayan.png
@@ -274,9 +274,10 @@ pastel2
 Rainbow Colormap
 ~~~~~~~~~~~~~~~~
 
-Don't use this one ! See here_ why
+Don't use this one ! See here_ and there_ why
 
-.. _here: http://data3.mprog.nl/course/15%20Readings/40%20Reading%204/Borland_Rainbow_Color_Map.pdf
+.. _here: https://www.nature.com/articles/s41467-020-19160-7
+.. _there: https://doi.org/10.1109/MCG.2007.323435
 
 rainbow
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -457,7 +457,7 @@ class XRImage(object):
             overviews_minsize (int): Minimum number of pixels for the smallest
                 overview size generated when `overviews` is auto-generated.
                 Defaults to 256.
-             (str): Resampling method
+            overviews_resampling (str): Resampling method
                 to use when generating overviews. This must be the name of an
                 enum value from :class:`rasterio.enums.Resampling` and
                 only takes effect if the `overviews` keyword argument is
@@ -542,10 +542,6 @@ class XRImage(object):
             tags['scale'], tags['offset'] = invert_scale_offset(scale, offset)
 
         # FIXME add metadata
-        # import rioxarray
-        # import threading
-        # return data.rio.to_raster(filename, tiled=True, lock=threading.Lock())
-
         r_file = RIOFile(filename, 'w', driver=driver,
                          width=data.sizes['x'], height=data.sizes['y'],
                          count=data.sizes['bands'],


### PR DESCRIPTION
This PR fixes the scale and offset being written as the repr of DataArrays when the stretch arguments are lists.

Also we update the link to the rainbow article.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)

