### PR TITLE
Fix palettize dtype for dask arrays

### DIFF
--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -134,7 +134,7 @@ def palettize(arr, colors, values):
 
 def _palettize_dask(darr, colors, values):
     """Apply a palette to a dask array."""
-    return darr.map_blocks(_palettize, values, dtype=colors.dtype)
+    return darr.map_blocks(_palettize, values, dtype=int)
 
 
 def _palettize(arr, values):

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -125,6 +125,7 @@ class TestColormapClass(unittest.TestCase):
         self.assertTrue(np.allclose(channels.compute(), [[0, 1, 2, 3],
                                                          [0, 1, 2, 3],
                                                          [0, 1, 2, 3]]))
+        assert channels.dtype == int
 
     def test_set_range(self):
         """Test set_range."""


### PR DESCRIPTION
The palettize method for colormap object when run on  dask-based array was giving an erraneous dtype to the result. Even if the computed result reverted to the correct dtype automatically, this PR ensure the dtype of the resulting dask array is correct.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)

