### PR TITLE
Allow customising scale and offset labels

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2125,9 +2125,9 @@ class TestXRImageSaveScaleOffset(unittest.TestCase):
         self.img.stretch()
         self._save_and_check_tags(expected_tags)
 
-    def _save_and_check_tags(self, expected_tags):
+    def _save_and_check_tags(self, expected_tags, **kwargs):
         with NamedTemporaryFile(suffix='.tif') as tmp:
-            self.img.save(tmp.name, include_scale_offset_tags=True)
+            self.img.save(tmp.name, include_scale_offset_tags=True, **kwargs)
 
             import rasterio as rio
             with rio.open(tmp.name) as f:
@@ -2142,6 +2142,16 @@ class TestXRImageSaveScaleOffset(unittest.TestCase):
 
         self.img.crude_stretch([1], [24])
         self._save_and_check_tags(expected_tags)
+
+    @pytest.mark.skipif(sys.platform.startswith('win'), reason="'NamedTemporaryFile' not supported on Windows")
+    def test_save_scale_offset_custom_labels(self):
+        """Test saving GeoTIFF with different scale/offset tag labels."""
+        expected_tags = {"gradient": 24.0 / 255, "axis_intercept": 0}
+        self.img.stretch()
+        self._save_and_check_tags(
+                expected_tags,
+                scale_label="gradient",
+                offset_label="axis_intercept")
 
 
 def _get_tags_after_writing_to_geotiff(data):

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -428,6 +428,8 @@ class XRImage(object):
                  keep_palette=False, cmap=None, overviews=None,
                  overviews_minsize=256, overviews_resampling=None,
                  include_scale_offset_tags=False,
+                 scale_label="scale",
+                 offset_label="offset",
                  **format_kwargs):
         """Save the image using rasterio.
 
@@ -467,6 +469,10 @@ class XRImage(object):
             include_scale_offset_tags (bool): Whether or not (default) to
                 include a ``scale`` and an ``offset`` tag in the data that would
                 help retrieving original data values from pixel values.
+            scale_label (str): Label to use for storing the scale if
+                using ``include_scale_offset_tags``.  Defaults to "scale".
+            offset_label (str): Label to use for storing the offset if
+                using ``include_scale_offset_tags``.  Defaults to "offset".
 
         Returns:
             The delayed or computed result of the saving.
@@ -539,7 +545,7 @@ class XRImage(object):
 
         if include_scale_offset_tags:
             scale, offset = self.get_scaling_from_history(data.attrs.get('enhancement_history', []))
-            tags['scale'], tags['offset'] = invert_scale_offset(scale, offset)
+            tags[scale_label], tags[offset_label] = invert_scale_offset(scale, offset)
 
         # FIXME add metadata
         r_file = RIOFile(filename, 'w', driver=driver,


### PR DESCRIPTION
When writing scale and offset to GDALMetaData, allow the user to
customise what labels are used.  Add two new keyword arguments to
`XRImage.rio_save`.  The default remains the status quo.


 - [x] Closes #84  (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
