### PR TITLE
Add .webp support

### DIFF
--- a/trollimage/image.py
+++ b/trollimage/image.py
@@ -75,7 +75,8 @@ def check_image_format(fformat):
              "png": "png",
              "xbm": "xbm",
              "xpm": "xpm",
-             'jp2': 'jp2',
+             "jp2": "jp2",
+             "webp": "webp",
              }
     fformat = fformat.lower()
     try:


### PR DESCRIPTION
First try to add .webp support. Webp images achive good compression and can easily muxed to videos which play looped in most browsers. I think there is some more work to do (error handling, modes...?). 

 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
