### PR TITLE
Use COG driver to write cloud optimized GeoTIFF

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1313,7 +1313,7 @@ class TestXRImage:
             img = xrimage.XRImage(data)
             assert np.issubdtype(img.data.dtype, np.integer)
             with NamedTemporaryFile(suffix='.tif') as tmp:
-                img.save(tmp.name, tiled=True, overviews=[])
+                img.save(tmp.name, tiled=True, overviews=[], driver='COG')
                 with rio.open(tmp.name) as f:
                     # The COG driver should add a tag indicating layout
                     assert(f.tags(ns='IMAGE_STRUCTURE')['LAYOUT'] == 'COG')

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1305,6 +1305,17 @@ class TestXRImage:
         from trollimage import xrimage
         import rasterio as rio
 
+        # trigger COG driver to create 2 overview levels
+        data = xr.DataArray(np.arange(1200*1200*3).reshape(1200, 1200, 3), dims=[
+            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+        img = xrimage.XRImage(data)
+        assert np.issubdtype(img.data.dtype, np.integer)
+        with NamedTemporaryFile(suffix='.tif') as tmp:
+            img.save(tmp.name, tiled=True, overviews=[])
+            with rio.open(tmp.name) as f:
+                assert(f.tags(ns='IMAGE_STRUCTURE')['LAYOUT'] == 'COG')
+                assert len(f.overviews(1)) == 2
+
         # numpy array image
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3), dims=[
             'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1306,15 +1306,16 @@ class TestXRImage:
         import rasterio as rio
 
         # trigger COG driver to create 2 overview levels
-        data = xr.DataArray(np.arange(1200*1200*3).reshape(1200, 1200, 3), dims=[
-            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
-        img = xrimage.XRImage(data)
-        assert np.issubdtype(img.data.dtype, np.integer)
-        with NamedTemporaryFile(suffix='.tif') as tmp:
-            img.save(tmp.name, tiled=True, overviews=[])
-            with rio.open(tmp.name) as f:
-                assert(f.tags(ns='IMAGE_STRUCTURE')['LAYOUT'] == 'COG')
-                assert len(f.overviews(1)) == 2
+        if rio.__gdal_version__ >= '3.1':
+            data = xr.DataArray(np.arange(1200*1200*3).reshape(1200, 1200, 3), dims=[
+                'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+            img = xrimage.XRImage(data)
+            assert np.issubdtype(img.data.dtype, np.integer)
+            with NamedTemporaryFile(suffix='.tif') as tmp:
+                img.save(tmp.name, tiled=True, overviews=[])
+                with rio.open(tmp.name) as f:
+                    assert(f.tags(ns='IMAGE_STRUCTURE')['LAYOUT'] == 'COG')
+                    assert len(f.overviews(1)) == 2
 
         # numpy array image
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3), dims=[

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -457,9 +457,9 @@ class XRImage(object):
 
                 If provided as an empty list, then levels will be
                 computed as powers of two until the last level has less
-                pixels than `overviews_minsize`.  If tiled=True then this
-                will be performed by the COG driver to produce a valid
-                Cloud Optimized GeoTIFF.
+                pixels than `overviews_minsize`.  If overviews=[] and tiled=True
+                and the tiles are square then this will be performed by the COG
+                driver to produce a valid Cloud Optimized GeoTIFF.
                 Default is to not add overviews.
             overviews_minsize (int): Minimum number of pixels for the smallest
                 overview size generated when `overviews` is auto-generated.
@@ -488,7 +488,7 @@ class XRImage(object):
                    'jp2': 'JP2OpenJPEG'}
         driver = drivers.get(fformat, fformat)
         if (driver == 'GTiff' and rasterio.__gdal_version__ >= '3.1' and
-                (format_kwargs.get('blockxsize',0) == format_kwargs.get('blockysize',0)) and
+                (format_kwargs.get('blockxsize', 0) == format_kwargs.get('blockysize', 0)) and
                 overviews == [] and
                 format_kwargs.get('tiled', None)):
             driver = 'COG'

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -485,6 +485,8 @@ class XRImage(object):
                    'tiff': 'GTiff',
                    'jp2': 'JP2OpenJPEG'}
         driver = drivers.get(fformat, fformat)
+        if driver == 'GTiff' and rasterio.__gdal_version__ >= '3.1':
+            driver = 'COG'
         if include_scale_offset_tags:
             warnings.warn(
                 "include_scale_offset_tags is deprecated, please use "
@@ -502,7 +504,7 @@ class XRImage(object):
         crs = None
         gcps = None
         transform = None
-        if driver in ['GTiff', 'JP2OpenJPEG']:
+        if driver in ['COG', 'GTiff', 'JP2OpenJPEG']:
             if not np.issubdtype(data.dtype, np.floating):
                 format_kwargs.setdefault('compress', 'DEFLATE')
             photometric_map = {

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -390,8 +390,8 @@ class XRImage(object):
                         which is normally selected from the filename or fformat.
                         This is an implementation detail normally avoided but
                         can be necessary if you wish to distinguish between
-                        GeoTIFF drivers (GTiff is the default, but you can
-                        specify COG to write a Cloud-Optimized GeoTIFF).
+                        GeoTIFF drivers ("GTiff" is the default, but you can
+                        specify "COG" to write a Cloud-Optimized GeoTIFF).
             fill_value (float): Replace invalid data values with this value
                                 and do not produce an Alpha band. Default
                                 behavior is to create an alpha band.
@@ -449,8 +449,8 @@ class XRImage(object):
                 it will be infered from the file extension.
             driver (string): The gdal driver to use. If not specified (default),
                 it will be inferred from the fformat, but you can override the
-                default GeoTIFF driver (GTiff) with 'COG' if you want to create
-                a Cloud_Optimized GeoTIFF (and set tiled=True,overviews=[]).
+                default GeoTIFF driver ("GTiff") with "COG" if you want to create
+                a Cloud_Optimized GeoTIFF (and set `tiled=True,overviews=[]`).
             fill_value (number): The value to fill the missing data with.
                 Default is ``None``, translating to trying to keep the data
                 transparent.
@@ -469,7 +469,7 @@ class XRImage(object):
                 If provided as an empty list, then levels will be
                 computed as powers of two until the last level has less
                 pixels than `overviews_minsize`.  If driver='COG' then use
-                overviews=[] to get a Cloud-Optimized GeoTIFF with a correct
+                `overviews=[]` to get a Cloud-Optimized GeoTIFF with a correct
                 set of overviews created automatically.
                 Default is to not add overviews.
             overviews_minsize (int): Minimum number of pixels for the smallest

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -486,14 +486,20 @@ class XRImage(object):
                    'tif': 'GTiff',
                    'tiff': 'GTiff',
                    'jp2': 'JP2OpenJPEG'}
+        # If fformat is specified then convert it into a driver
         driver = drivers.get(fformat, fformat)
+        # If driver is specified then it takes precedence
+        driver = format_kwargs.pop('driver', driver)
+        # If it looks like COG would be a better choice then change driver
         if (driver == 'GTiff' and rasterio.__gdal_version__ >= '3.1' and
                 (format_kwargs.get('blockxsize', 0) == format_kwargs.get('blockysize', 0)) and
                 overviews == [] and
                 format_kwargs.get('tiled', None)):
             driver = 'COG'
+        # The COG driver adds overviews so we don't need to create them ourself.
+        # One thing we can't do is prevent any overviews, if we use None then
+        # the COG driver will create automatically, we can't pass OVERVIEWS=NONE.
         if driver == 'COG' and overviews == []:
-            # The COG driver adds overviews so we don't need to create them ourself
             overviews = None
         if include_scale_offset_tags:
             warnings.warn(

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -457,7 +457,9 @@ class XRImage(object):
 
                 If provided as an empty list, then levels will be
                 computed as powers of two until the last level has less
-                pixels than `overviews_minsize`.
+                pixels than `overviews_minsize`.  If tiled=True then this
+                will be performed by the COG driver to produce a valid
+                Cloud Optimized GeoTIFF.
                 Default is to not add overviews.
             overviews_minsize (int): Minimum number of pixels for the smallest
                 overview size generated when `overviews` is auto-generated.

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -488,6 +488,7 @@ class XRImage(object):
                    'jp2': 'JP2OpenJPEG'}
         driver = drivers.get(fformat, fformat)
         if (driver == 'GTiff' and rasterio.__gdal_version__ >= '3.1' and
+                (format_kwargs.get('blockxsize',0) == format_kwargs.get('blockysize',0)) and
                 overviews == [] and
                 format_kwargs.get('tiled', None)):
             driver = 'COG'

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -492,7 +492,9 @@ class XRImage(object):
                 overviews == [] and
                 format_kwargs.get('tiled', None)):
             driver = 'COG'
-            overviews = None  # the COG driver adds them automatically
+        if driver == 'COG' and overviews == []:
+            # The COG driver adds overviews so we don't need to create them ourself
+            overviews = None
         if include_scale_offset_tags:
             warnings.warn(
                 "include_scale_offset_tags is deprecated, please use "

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -488,7 +488,7 @@ class XRImage(object):
         if (driver == 'GTiff' and rasterio.__gdal_version__ >= '3.1' and
                 overviews == []):
             driver = 'COG'
-            overviews = None # the COG driver does this automatically
+            overviews = None  # the COG driver does this automatically
         if include_scale_offset_tags:
             warnings.warn(
                 "include_scale_offset_tags is deprecated, please use "

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -373,7 +373,7 @@ class XRImage(object):
         return ''.join(self.data['bands'].values)
 
     def save(self, filename, fformat=None, fill_value=None, compute=True,
-             keep_palette=False, cmap=None, **format_kwargs):
+             keep_palette=False, cmap=None, driver=None, **format_kwargs):
         """Save the image to the given *filename*.
 
         Args:
@@ -386,6 +386,12 @@ class XRImage(object):
                            If the format allows, geographical information will
                            be saved to the ouput file, in the form of grid
                            mapping or ground control points.
+            driver (str): can override the choice of rasterio/gdal driver
+                        which is normally selected from the filename or fformat.
+                        This is an implementation detail normally avoided but
+                        can be necessary if you wish to distinguish between
+                        GeoTIFF drivers (GTiff is the default, but you can
+                        specify COG to write a Cloud-Optimized GeoTIFF).
             fill_value (float): Replace invalid data values with this value
                                 and do not produce an Alpha band. Default
                                 behavior is to create an alpha band.
@@ -420,7 +426,7 @@ class XRImage(object):
         fformat = fformat or kwformat or os.path.splitext(filename)[1][1:]
         if fformat in ('tif', 'tiff', 'jp2') and rasterio:
 
-            return self.rio_save(filename, fformat=fformat,
+            return self.rio_save(filename, fformat=fformat, driver=driver,
                                  fill_value=fill_value, compute=compute,
                                  keep_palette=keep_palette, cmap=cmap,
                                  **format_kwargs)
@@ -433,6 +439,7 @@ class XRImage(object):
                  overviews_minsize=256, overviews_resampling=None,
                  include_scale_offset_tags=False,
                  scale_offset_tags=None,
+                 driver=None,
                  **format_kwargs):
         """Save the image using rasterio.
 
@@ -440,6 +447,10 @@ class XRImage(object):
             filename (string): The filename to save to.
             fformat (string): The format to save to. If not specified (default),
                 it will be infered from the file extension.
+            driver (string): The gdal driver to use. If not specified (default),
+                it will be inferred from the fformat, but you can override the
+                default GeoTIFF driver (GTiff) with 'COG' if you want to create
+                a Cloud_Optimized GeoTIFF (and set tiled=True,overviews=[]).
             fill_value (number): The value to fill the missing data with.
                 Default is ``None``, translating to trying to keep the data
                 transparent.
@@ -457,9 +468,9 @@ class XRImage(object):
 
                 If provided as an empty list, then levels will be
                 computed as powers of two until the last level has less
-                pixels than `overviews_minsize`.  If overviews=[] and tiled=True
-                and the tiles are square then this will be performed by the COG
-                driver to produce a valid Cloud Optimized GeoTIFF.
+                pixels than `overviews_minsize`.  If driver='COG' then use
+                overviews=[] to get a Cloud-Optimized GeoTIFF with a correct
+                set of overviews created automatically.
                 Default is to not add overviews.
             overviews_minsize (int): Minimum number of pixels for the smallest
                 overview size generated when `overviews` is auto-generated.
@@ -486,16 +497,8 @@ class XRImage(object):
                    'tif': 'GTiff',
                    'tiff': 'GTiff',
                    'jp2': 'JP2OpenJPEG'}
-        # If fformat is specified then convert it into a driver
-        driver = drivers.get(fformat, fformat)
-        # If driver is specified then it takes precedence
-        driver = format_kwargs.pop('driver', driver)
-        # If it looks like COG would be a better choice then change driver
-        if (driver == 'GTiff' and rasterio.__gdal_version__ >= '3.1' and
-                (format_kwargs.get('blockxsize', 0) == format_kwargs.get('blockysize', 0)) and
-                overviews == [] and
-                format_kwargs.get('tiled', None)):
-            driver = 'COG'
+        # If fformat is specified but not driver then convert it into a driver
+        driver = driver or drivers.get(fformat, fformat)
         # The COG driver adds overviews so we don't need to create them ourself.
         # One thing we can't do is prevent any overviews, if we use None then
         # the COG driver will create automatically, we can't pass OVERVIEWS=NONE.


### PR DESCRIPTION

 - [X] Closes #93 
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [X] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)

This suggested patch does work, but produces this output:
```
ERROR 4: img_20211021-1852_eurol_overview.tif: No such file or directory
Warning 6: driver COG does not support creation option ZLEVEL
Warning 6: driver COG does not support creation option TILED
Warning 6: driver COG does not support creation option BLOCKXSIZE
Warning 6: driver COG does not support creation option BLOCKYSIZE
Warning 6: driver COG does not support creation option PHOTOMETRIC
```
Despite the ERROR it does indeed produce a correct file of that name.

The Warnings are probably because the COG driver sets those options itself.
