### PR TITLE
Fix XRImage reopening geotiff with the incorrect mode

### DIFF
--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -133,13 +133,13 @@ class RIOFile(object):
     def write(self, *args, **kwargs):
         """Write to the file."""
         with self.lock:
-            self.open('a')
+            self.open('r+')
             return self.rfile.write(*args, **kwargs)
 
     def build_overviews(self, *args, **kwargs):
         """Write overviews."""
         with self.lock:
-            self.open('a')
+            self.open('r+')
             return self.rfile.build_overviews(*args, **kwargs)
 
     def update_tags(self, *args, **kwargs):


### PR DESCRIPTION
I brought this up on slack, but while playing around with some dask stuff I noticed I was getting an error from rasterio about trollimage trying to reopen a geotiff with mode `"a"`. Turns out that mode doesn't exist for rasterio and never has. Only r, r+, w, w+ are allowed. This PR fixes that usage.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
