### PR TITLE
Improve 'log' stretching with static limits and choosing log base

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1577,7 +1577,8 @@ class TestXRImage:
             ([0.0, 1.0 / 74.0, 2.0 / 74.0], [72.0 / 74.0, 73.0 / 74.0, 1.0]),
         ]
     )
-    def test_logarithmic_stretch(self, min_stretch, max_stretch):
+    @pytest.mark.parametrize("base", ["ln", "10", "2"])
+    def test_logarithmic_stretch(self, min_stretch, max_stretch, base):
         """Test logarithmic strecthing."""
         import xarray as xr
         from trollimage import xrimage
@@ -1588,7 +1589,8 @@ class TestXRImage:
         img = xrimage.XRImage(data)
         img.stretch(stretch='logarithmic',
                     min_stretch=min_stretch,
-                    max_stretch=max_stretch)
+                    max_stretch=max_stretch,
+                    base=base)
         enhs = img.data.attrs['enhancement_history'][0]
         assert enhs == {'log_factor': 100.0}
         res = np.array([[[0., 0., 0.],

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1570,7 +1570,14 @@ class TestXRImage:
 
         np.testing.assert_allclose(img.data.values, res, atol=1.e-6)
 
-    def test_logarithmic_stretch(self):
+    @pytest.mark.parametrize(
+        ("min_stretch", "max_stretch"),
+        [
+            (None, None),
+            ([0.0, 1.0 / 74.0, 2.0 / 74.0], [72.0 / 74.0, 73.0 / 74.0, 1.0]),
+        ]
+    )
+    def test_logarithmic_stretch(self, min_stretch, max_stretch):
         """Test logarithmic strecthing."""
         import xarray as xr
         from trollimage import xrimage
@@ -1579,7 +1586,9 @@ class TestXRImage:
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
-        img.stretch(stretch='logarithmic')
+        img.stretch(stretch='logarithmic',
+                    min_stretch=min_stretch,
+                    max_stretch=max_stretch)
         enhs = img.data.attrs['enhancement_history'][0]
         assert enhs == {'log_factor': 100.0}
         res = np.array([[[0., 0., 0.],

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1572,7 +1572,7 @@ class TestXRImage:
             ([0.0, 1.0 / 74.0, 2.0 / 74.0], [72.0 / 74.0, 73.0 / 74.0, 1.0]),
         ]
     )
-    @pytest.mark.parametrize("base", ["ln", "10", "2"])
+    @pytest.mark.parametrize("base", ["e", "10", "2"])
     def test_logarithmic_stretch(self, min_stretch, max_stretch, base):
         """Test logarithmic strecthing."""
         import xarray as xr

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1,26 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2009-2015, 2017.
-
-# Author(s):
-
-#   Martin Raspaud <martin.raspaud@smhi.se>
-#   Adam Dybbroe <adam.dybbroe@smhi.se>
-
-# This file is part of mpop.
-
-# mpop is free software: you can redistribute it and/or modify it
+# Copyright (c) 2009-2021 trollimage developers
+#
+# This file is part of trollimage.
+#
+# trollimage is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
-# mpop is distributed in the hope that it will be useful, but
+#
+# trollimage is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
-# along with mpop.  If not, see <http://www.gnu.org/licenses/>.
+# along with trollimage.  If not, see <http://www.gnu.org/licenses/>.
 """Module for testing the image and xrimage modules."""
 import os
 import random
@@ -1582,15 +1577,17 @@ class TestXRImage:
         """Test logarithmic strecthing."""
         import xarray as xr
         from trollimage import xrimage
+        from .utils import assert_maximum_dask_computes
 
         arr = np.arange(75).reshape(5, 5, 3) / 74.
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
-        img = xrimage.XRImage(data)
-        img.stretch(stretch='logarithmic',
-                    min_stretch=min_stretch,
-                    max_stretch=max_stretch,
-                    base=base)
+        with assert_maximum_dask_computes(0):
+            img = xrimage.XRImage(data)
+            img.stretch(stretch='logarithmic',
+                        min_stretch=min_stretch,
+                        max_stretch=max_stretch,
+                        base=base)
         enhs = img.data.attrs['enhancement_history'][0]
         assert enhs == {'log_factor': 100.0}
         res = np.array([[[0., 0., 0.],

--- a/trollimage/tests/utils.py
+++ b/trollimage/tests/utils.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 trollimage developers
+#
+# This file is part of trollimage.
+#
+# trollimage is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# trollimage is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with trollimage.  If not, see <http://www.gnu.org/licenses/>.
+"""Helper classes and functions for running and writing tests."""
+
+from contextlib import contextmanager
+
+
+class CustomScheduler:
+    """Scheduler raising an exception if data are computed too many times."""
+
+    def __init__(self, max_computes=1):
+        """Set starting and maximum compute counts."""
+        self.max_computes = max_computes
+        self.total_computes = 0
+
+    def __call__(self, dsk, keys, **kwargs):
+        """Compute dask task and keep track of number of times we do so."""
+        import dask
+        self.total_computes += 1
+        if self.total_computes > self.max_computes:
+            raise RuntimeError("Too many dask computations were scheduled: "
+                               "{}".format(self.total_computes))
+        return dask.get(dsk, keys, **kwargs)
+
+
+@contextmanager
+def assert_maximum_dask_computes(max_computes=1):
+    """Context manager to make sure dask computations are not executed more than ``max_computes`` times."""
+    import dask
+    with dask.config.set(scheduler=CustomScheduler(max_computes=max_computes)) as new_config:
+        yield new_config

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1323,7 +1323,26 @@ class XRImage(object):
         self.data.attrs.setdefault('enhancement_history', []).append({'hist_equalize': True})
 
     def stretch_logarithmic(self, factor=100., base="ln", min_stretch=None, max_stretch=None):
-        """Move data into range [1:factor] through normalized logarithm."""
+        """Move data into range [1:factor] through normalized logarithm.
+
+        Args:
+            factor (float): Maximum of the range data will be scaled to
+                before applying the log function. Image data will be scaled
+                to a 1 to ``factor`` range.
+            base (str): Type of log to use. Defaults to natural log ("ln"),
+                but can also be "10" for base 10 log or "2" for base 2 log.
+            min_stretch (float or list): Minimum input value to scale from.
+                Data will be clipped to this value before being scaled to
+                the 1:factor range. By default (None), the limits are computed
+                on the fly but with a performance penalty. May also be a list
+                for multi-band images.
+            max_stretch (float or list): Maximum input value to scale from.
+                Data will be clipped to this value before being scaled to
+                the 1:factor range. By default (None), the limits are computed
+                on the fly but with a performance penalty. May also be a list
+                for multi-band images.
+
+        """
         logger.debug("Perform a logarithmic contrast stretch.")
         crange = (0., 1.0)
         log_func = np.log if base == "ln" else getattr(np, "log" + base)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1322,14 +1322,14 @@ class XRImage(object):
                                   axis=self.data.dims.index('bands'))
         self.data.attrs.setdefault('enhancement_history', []).append({'hist_equalize': True})
 
-    def stretch_logarithmic(self, factor=100., base="ln", min_stretch=None, max_stretch=None):
+    def stretch_logarithmic(self, factor=100., base="e", min_stretch=None, max_stretch=None):
         """Move data into range [1:factor] through normalized logarithm.
 
         Args:
             factor (float): Maximum of the range data will be scaled to
                 before applying the log function. Image data will be scaled
                 to a 1 to ``factor`` range.
-            base (str): Type of log to use. Defaults to natural log ("ln"),
+            base (str): Type of log to use. Defaults to natural log ("e"),
                 but can also be "10" for base 10 log or "2" for base 2 log.
             min_stretch (float or list): Minimum input value to scale from.
                 Data will be clipped to this value before being scaled to
@@ -1345,7 +1345,7 @@ class XRImage(object):
         """
         logger.debug("Perform a logarithmic contrast stretch.")
         crange = (0., 1.0)
-        log_func = np.log if base == "ln" else getattr(np, "log" + base)
+        log_func = np.log if base == "e" else getattr(np, "log" + base)
         min_stretch, max_stretch = self._convert_log_minmax_stretch(min_stretch, max_stretch)
 
         b__ = float(crange[1] - crange[0]) / log_func(factor)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1352,7 +1352,7 @@ class XRImage(object):
         c__ = float(crange[0])
 
         def _band_log(arr, min_input, max_input):
-            slope = (factor - 1.) / float(max_input - min_input)
+            slope = (factor - 1.) / (max_input - min_input)
             arr = np.clip(arr, min_input, max_input)
             arr = 1. + (arr - min_input) * slope
             arr = c__ + b__ * log_func(arr)
@@ -1364,8 +1364,8 @@ class XRImage(object):
                 continue
             band_data = self.data.sel(bands=band)
             res = _band_log(band_data.data,
-                            float(min_stretch[band_idx]),
-                            float(max_stretch[band_idx]))
+                            min_stretch[band_idx],
+                            max_stretch[band_idx])
             band_results.append(res)
 
         if 'A' in self.data.coords['bands'].values:

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -374,10 +374,13 @@ class XRImage(object):
 
     @staticmethod
     def _gtiff_to_cog_kwargs(format_kwargs):
-        """ The COG driver automatically sets some format options
-        but zlevel is called level and blockxsize is called blocksize.
-        Convert kwargs to save() from GTiff driver to COG driver. """
+        """Convert GDAL Geotiff driver options to COG driver options.
 
+        The COG driver automatically sets some format options
+        but zlevel is called level and blockxsize is called blocksize.
+        Convert kwargs to save() from GTiff driver to COG driver.
+
+        """
         format_kwargs.pop('photometric', None)
         if 'zlevel' in format_kwargs:
             format_kwargs['level'] = format_kwargs.pop('zlevel')
@@ -1319,33 +1322,52 @@ class XRImage(object):
                                   axis=self.data.dims.index('bands'))
         self.data.attrs.setdefault('enhancement_history', []).append({'hist_equalize': True})
 
-    def stretch_logarithmic(self, factor=100.):
+    def stretch_logarithmic(self, factor=100., base="ln", min_stretch=None, max_stretch=None):
         """Move data into range [1:factor] through normalized logarithm."""
         logger.debug("Perform a logarithmic contrast stretch.")
         crange = (0., 1.0)
+        log_func = np.log if base == "ln" else getattr(np, "log" + base)
+        min_stretch, max_stretch = self._convert_log_minmax_stretch(min_stretch, max_stretch)
 
-        b__ = float(crange[1] - crange[0]) / np.log(factor)
+        b__ = float(crange[1] - crange[0]) / log_func(factor)
         c__ = float(crange[0])
 
-        def _band_log(arr):
-            slope = (factor - 1.) / float(arr.max() - arr.min())
-            arr = 1. + (arr - arr.min()) * slope
-            arr = c__ + b__ * da.log(arr)
+        def _band_log(arr, min_input, max_input):
+            # log10(Chl_a + 1) / 0.00519
+            # 255 * (log10(Chl_a + 1) / np.log(20 + 1))
+            # min_input = 0
+            # slope = 1
+            slope = (factor - 1.) / float(max_input - min_input)
+            arr = np.clip(arr, min_input, max_input)
+            arr = 1. + (arr - min_input) * slope
+            arr = c__ + b__ * log_func(arr)
             return arr
 
         band_results = []
-        for band in self.data['bands'].values:
+        for band_idx, band in enumerate(self.data['bands'].values):
             if band == 'A':
                 continue
             band_data = self.data.sel(bands=band)
-            res = _band_log(band_data.data)
+            res = _band_log(band_data.data, min_stretch[band_idx], max_stretch[band_idx])
             band_results.append(res)
 
         if 'A' in self.data.coords['bands'].values:
             band_results.append(self.data.sel(bands='A'))
-        self.data.data = da.stack(band_results,
-                                  axis=self.data.dims.index('bands'))
+        self.data.data = da.stack(band_results, axis=self.data.dims.index('bands'))
         self.data.attrs.setdefault('enhancement_history', []).append({'log_factor': factor})
+
+    def _convert_log_minmax_stretch(self, min_stretch, max_stretch):
+        if min_stretch is None:
+            non_band_dims = tuple(x for x in self.data.dims if x != 'bands')
+            min_stretch = self.data.min(dim=non_band_dims)
+        if max_stretch is None:
+            non_band_dims = tuple(x for x in self.data.dims if x != 'bands')
+            max_stretch = self.data.max(dim=non_band_dims)
+        if not isinstance(min_stretch, (list, tuple)):
+            min_stretch = [min_stretch] * self.data.sizes.get("bands", 1)
+        if not isinstance(max_stretch, (list, tuple)):
+            max_stretch = [max_stretch] * self.data.sizes.get("bands", 1)
+        return min_stretch, max_stretch
 
     def stretch_weber_fechner(self, k, s0):
         """Stretch according to the Weber-Fechner law.


### PR DESCRIPTION
This PR adds some functionality I need to reproduce some products that a Polar2Grid user needs. This PR adds static limits to the logarithmic stretching (min_stretch/max_stretch) as well as the ability to choose the type of `log` function that is used. The defaults maintain backwards compatibility (natural log, dynamic limits, etc).

However, one thing I'm confused about is that even with different log functions the results are the same. Is that because the slope of the logs are all the same within those ranges? How does match work?

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
