### PR TITLE
Update Colormap.set_range to support flipped values

### DIFF
--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -172,8 +172,7 @@ class Colormap(object):
             aren't provided.
         values: One dimensional array-like of control points where
             each corresponding color is applied. Must be the same number of
-            elements as colors and must be monotonically increasing or
-            monotonically decreasing.
+            elements as colors and must be monotonic.
         colors: Two dimensional array-like of RGB or RGBA colors where each
             color is applied to a specific control point. Must be the same
             number of colors as control points (values). Colors should be

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -107,11 +107,7 @@ def _interpolate_alpha(arr, colors, values):
 
 def _mask_channels(channels, arr):
     """Mask the channels if arr is a masked array."""
-    try:
-        channels = [_mask_array(channel, arr) for channel in channels]
-    except AttributeError:
-        pass
-    return channels
+    return [_mask_array(channel, arr) for channel in channels]
 
 
 def _mask_array(new_array, arr):

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -71,7 +71,6 @@ def _colorize(arr, colors, values):
 
 
 def _interpolate_rgb_colors(arr, colors, values):
-    # monotonically increasing
     interp_xp_coords = np.array(values)
     hcl_colors = _convert_rgb_list_to_hcl(colors)
     interp_y_coords = np.array(hcl_colors)

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -145,10 +145,17 @@ def _palettize(arr, values):
 
 
 def _digitize_array(arr, values):
-    new_arr = np.digitize(arr.ravel(),
-                          np.concatenate((values,
-                                          [max(np.nanmax(arr),
-                                               values.max()) + 1])))
+    if values[0] <= values[-1]:
+        # monotonic increasing values
+        outside_range_bin = max(np.nanmax(arr), values.max()) + 1
+        right = False
+    else:
+        # monotonic decreasing values
+        outside_range_bin = min(np.nanmin(arr), values.min()) - 1
+        right = True
+    bins = np.concatenate((values, [outside_range_bin]))
+
+    new_arr = np.digitize(arr.ravel(), bins, right=right)
     new_arr -= 1
     new_arr = new_arr.clip(min=0, max=len(values) - 1)
     return new_arr

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -71,10 +71,17 @@ def _colorize(arr, colors, values):
 
 
 def _interpolate_rgb_colors(arr, colors, values):
+    # monotonically increasing
+    interp_xp_coords = np.array(values)
     hcl_colors = _convert_rgb_list_to_hcl(colors)
+    interp_y_coords = np.array(hcl_colors)
+    if values[0] > values[-1]:
+        # monotonically decreasing
+        interp_xp_coords = interp_xp_coords[::-1]
+        interp_y_coords = interp_y_coords[::-1]
     channels = [np.interp(arr,
-                          np.array(values),
-                          np.array(hcl_colors)[:, i])
+                          interp_xp_coords,
+                          interp_y_coords[:, i])
                 for i in range(3)]
     channels = list(hcl2rgb(*channels))
     return channels

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -412,31 +412,47 @@ class TestColormap:
                                                         [0, 1, 2, 3]])
         assert channels.dtype == int
 
-    def test_colorize_no_interpolation(self):
+    @pytest.mark.parametrize(
+        ("input_cmap_func", "expected_result"),
+        [
+            (_mono_inc_colormap, _four_rgb_colors()),
+            (_mono_dec_colormap, _four_rgb_colors()[::-1]),
+        ]
+    )
+    def test_colorize_no_interpolation(self, input_cmap_func, expected_result):
         """Test colorize."""
         data = np.array([1, 2, 3, 4])
-
-        cm = _mono_inc_colormap()
+        cm = input_cmap_func()
         channels = cm.colorize(data)
-        for i in range(3):
-            np.testing.assert_allclose(channels[i],
-                                       cm.colors[:, i],
-                                       atol=0.001)
+        output_colors = [channels[:, i] for i in range(data.size)]
+        for output_color, expected_color in zip(output_colors, expected_result):
+            np.testing.assert_allclose(output_color, expected_color, atol=0.001)
 
-    def test_colorize_with_interpolation(self):
-        """Test colorize."""
+    @pytest.mark.parametrize(
+        ("input_cmap_func", "expected_result"),
+        [
+            (_mono_inc_colormap,
+             np.array([
+                 [0.22178232, 1.08365532, 0.49104964],
+                 [0.61069262, 0.94644083, 1.20509947],
+                 [0.50011605, 0.50000605, 0.49989589],
+                 [0.0, 0.0, 0.0]])),
+            (_mono_dec_colormap,
+             np.array([
+                 [0.50011605, 0.50000605, 0.49989589],
+                 [0.61069262, 0.94644083, 1.20509947],
+                 [0.22178232, 1.08365532, 0.49104964],
+                 [1.0, 1.0, 0.0]])),
+        ]
+    )
+    def test_colorize_with_interpolation(self, input_cmap_func, expected_result):
+        """Test colorize where data values require interpolation between colors."""
         data = np.array([1.5, 2.5, 3.5, 4])
-
-        expected_channels = [np.array([0.22178232, 0.61069262, 0.50011605, 0.]),
-                             np.array([1.08365532, 0.94644083, 0.50000605, 0.]),
-                             np.array([0.49104964, 1.20509947, 0.49989589, 0.])]
-
-        cm = _mono_inc_colormap()
+        cm = input_cmap_func()
         channels = cm.colorize(data)
-        for i in range(3):
-            np.testing.assert_allclose(channels[i],
-                                       expected_channels[i],
-                                       atol=0.001)
+        output_colors = [channels[:, i] for i in range(data.size)]
+        for output_color, expected_color in zip(output_colors, expected_result):
+            np.testing.assert_allclose(output_color, expected_color, atol=0.001)
 
     def test_colorize_dask_with_interpolation(self):
         """Test colorize dask arrays."""

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -390,16 +390,26 @@ class TestColormap:
         _assert_values_changed(cmap, new_cmap, inplace, orig_values)
         _assert_unchanged_colors(cmap, new_cmap, orig_colors)
 
-    def test_palettize_mono_inc_in_range(self):
-        """Test palettize with monotonic increasing values inside the set range."""
+    @pytest.mark.parametrize(
+        ("input_values", "expected_result"),
+        [
+            ((1, 2, 3, 4), (0, 1, 2, 3)),  # mono increasing
+            ((4, 3, 2, 1), (3, 2, 1, 0)),  # mono decreasing
+        ]
+    )
+    def test_palettize_in_range(self, input_values, expected_result):
+        """Test palettize with values inside the set range."""
         data = np.array([1, 2, 3, 4])
-        cm_ = colormap.Colormap((1, (1.0, 1.0, 0.0)),
-                                (2, (0.0, 1.0, 1.0)),
-                                (3, (1, 1, 1)),
-                                (4, (0, 0, 0)))
+        colors = [
+            (1.0, 1.0, 0.0),
+            (0.0, 1.0, 1.0),
+            (1.0, 1.0, 1.0),
+            (0.0, 0.0, 0.0),
+        ]
+        cm_ = colormap.Colormap(values=input_values, colors=colors)
         channels, colors = cm_.palettize(data)
         np.testing.assert_allclose(colors, cm_.colors)
-        assert all(channels == [0, 1, 2, 3])
+        assert all(channels == expected_result)
 
     def test_palettize_mono_inc_out_range(self):
         """Test palettize with a value outside the colormap values."""

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -87,20 +87,6 @@ class TestColormapClass(unittest.TestCase):
                                         expected_channel,
                                         atol=0.001))
 
-    def test_palettize_dask(self):
-        """Test palettize on a dask array."""
-        import dask.array as da
-        data = da.from_array(np.array([[1, 2, 3, 4],
-                                       [1, 2, 3, 4],
-                                       [1, 2, 3, 4]]), chunks=2)
-        channels, colors = self.colormap.palettize(data)
-        assert isinstance(channels, da.Array)
-        self.assertTrue(np.allclose(colors, self.colormap.colors))
-        self.assertTrue(np.allclose(channels.compute(), [[0, 1, 2, 3],
-                                                         [0, 1, 2, 3],
-                                                         [0, 1, 2, 3]]))
-        assert channels.dtype == int
-
     def test_set_range(self):
         """Test set_range."""
         cm_ = colormap.Colormap((1, (1.0, 1.0, 0.0)),
@@ -437,6 +423,24 @@ class TestColormap:
         channels, colors = cm_.palettize(data)
         np.testing.assert_allclose(colors, cm_.colors)
         assert all(channels == [0, 0, 1, 2, 3, 3])
+
+    def test_palettize_mono_inc_in_range_dask(self):
+        """Test palettize on a dask array."""
+        import dask.array as da
+        data = da.from_array(np.array([[1, 2, 3, 4],
+                                       [1, 2, 3, 4],
+                                       [1, 2, 3, 4]]), chunks=2)
+        cm_ = colormap.Colormap((1, (1.0, 1.0, 0.0)),
+                                (2, (0.0, 1.0, 1.0)),
+                                (3, (1, 1, 1)),
+                                (4, (0, 0, 0)))
+        channels, colors = cm_.palettize(data)
+        assert isinstance(channels, da.Array)
+        np.testing.assert_allclose(colors, cm_.colors)
+        np.testing.assert_allclose(channels.compute(), [[0, 1, 2, 3],
+                                                        [0, 1, 2, 3],
+                                                        [0, 1, 2, 3]])
+        assert channels.dtype == int
 
 
 def _assert_monotonic_values(cmap, increasing=True):

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -404,32 +404,36 @@ class TestColormap:
         _assert_values_changed(cmap, new_cmap, inplace, orig_values)
         _assert_unchanged_colors(cmap, new_cmap, orig_colors)
 
-    def test_palettize(self):
-        """Test palettize."""
+    def test_palettize_mono_inc_in_range(self):
+        """Test palettize with monotonic increasing values inside the set range."""
         data = np.array([1, 2, 3, 4])
         cm_ = colormap.Colormap((1, (1.0, 1.0, 0.0)),
                                 (2, (0.0, 1.0, 1.0)),
                                 (3, (1, 1, 1)),
                                 (4, (0, 0, 0)))
-
         channels, colors = cm_.palettize(data)
         np.testing.assert_allclose(colors, cm_.colors)
         assert all(channels == [0, 1, 2, 3])
 
+    def test_palettize_mono_inc_out_range(self):
+        """Test palettize with a value outside the colormap values."""
         cm_ = colormap.Colormap((0, (0.0, 0.0, 0.0)),
                                 (1, (1.0, 1.0, 1.0)),
                                 (2, (2, 2, 2)),
                                 (3, (3, 3, 3)))
-
         data = np.arange(-1, 5)
-
         channels, colors = cm_.palettize(data)
         np.testing.assert_allclose(colors, cm_.colors)
         assert all(channels == [0, 0, 1, 2, 3, 3])
 
+    def test_palettize_mono_inc_nan(self):
+        """Test palettize with monotonic increasing values with a NaN."""
+        cm_ = colormap.Colormap((0, (0.0, 0.0, 0.0)),
+                                (1, (1.0, 1.0, 1.0)),
+                                (2, (2, 2, 2)),
+                                (3, (3, 3, 3)))
         data = np.arange(-1.0, 5.0)
         data[-1] = np.nan
-
         channels, colors = cm_.palettize(data)
         np.testing.assert_allclose(colors, cm_.colors)
         assert all(channels == [0, 0, 1, 2, 3, 3])

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -38,55 +38,6 @@ class TestColormapClass(unittest.TestCase):
                                           (3, (1, 1, 1)),
                                           (4, (0, 0, 0)))
 
-    def test_colorize_no_interpolation(self):
-        """Test colorize."""
-        data = np.array([1, 2, 3, 4])
-
-        channels = self.colormap.colorize(data)
-        for i in range(3):
-            self.assertTrue(np.allclose(channels[i],
-                                        self.colormap.colors[:, i],
-                                        atol=0.001))
-
-    def test_colorize_with_interpolation(self):
-        """Test colorize."""
-        data = np.array([1.5, 2.5, 3.5, 4])
-
-        expected_channels = [np.array([0.22178232, 0.61069262, 0.50011605, 0.]),
-                             np.array([1.08365532, 0.94644083, 0.50000605, 0.]),
-                             np.array([0.49104964, 1.20509947, 0.49989589, 0.])]
-
-        channels = self.colormap.colorize(data)
-        for i in range(3):
-            self.assertTrue(np.allclose(channels[i],
-                                        expected_channels[i],
-                                        atol=0.001))
-
-    def test_colorize_dask_with_interpolation(self):
-        """Test colorize dask arrays."""
-        import dask.array as da
-        data = da.from_array(np.array([[1.5, 2.5, 3.5, 4],
-                                       [1.5, 2.5, 3.5, 4],
-                                       [1.5, 2.5, 3.5, 4]]), chunks=2)
-
-        expected_channels = [np.array([[0.22178232, 0.61069262, 0.50011605, 0.],
-                                       [0.22178232, 0.61069262, 0.50011605, 0.],
-                                       [0.22178232, 0.61069262, 0.50011605, 0.]]),
-                             np.array([[1.08365532, 0.94644083, 0.50000605, 0.],
-                                       [1.08365532, 0.94644083, 0.50000605, 0.],
-                                       [1.08365532, 0.94644083, 0.50000605, 0.]]),
-                             np.array([[0.49104964, 1.20509947, 0.49989589, 0.],
-                                       [0.49104964, 1.20509947, 0.49989589, 0.],
-                                       [0.49104964, 1.20509947, 0.49989589, 0.]])]
-
-        channels = self.colormap.colorize(data)
-        for i, expected_channel in enumerate(expected_channels):
-            current_channel = channels[i, :, :]
-            assert isinstance(current_channel, da.Array)
-            self.assertTrue(np.allclose(current_channel.compute(),
-                                        expected_channel,
-                                        atol=0.001))
-
     def test_set_range(self):
         """Test set_range."""
         cm_ = colormap.Colormap((1, (1.0, 1.0, 0.0)),
@@ -194,6 +145,16 @@ COLORS_RGBA1 = np.array([
     [0.0, 0.2, 0.2, 0.0],
     [0.0, 0.2, 0.0, 1.0],
 ])
+
+
+@pytest.fixture
+def mono_inc_colormap():
+    """Create fake monotonically increasing colormap."""
+    cmap = colormap.Colormap((1, (1.0, 1.0, 0.0)),
+                             (2, (0.0, 1.0, 1.0)),
+                             (3, (1, 1, 1)),
+                             (4, (0, 0, 0)))
+    return cmap
 
 
 class TestColormap:
@@ -434,23 +395,68 @@ class TestColormap:
         np.testing.assert_allclose(colors, cm_.colors)
         assert all(channels == [0, 0, 1, 2, 3, 3])
 
-    def test_palettize_mono_inc_in_range_dask(self):
+    def test_palettize_mono_inc_in_range_dask(self, mono_inc_colormap):
         """Test palettize on a dask array."""
         import dask.array as da
         data = da.from_array(np.array([[1, 2, 3, 4],
                                        [1, 2, 3, 4],
                                        [1, 2, 3, 4]]), chunks=2)
-        cm_ = colormap.Colormap((1, (1.0, 1.0, 0.0)),
-                                (2, (0.0, 1.0, 1.0)),
-                                (3, (1, 1, 1)),
-                                (4, (0, 0, 0)))
-        channels, colors = cm_.palettize(data)
+        channels, colors = mono_inc_colormap.palettize(data)
         assert isinstance(channels, da.Array)
-        np.testing.assert_allclose(colors, cm_.colors)
+        np.testing.assert_allclose(colors, mono_inc_colormap.colors)
         np.testing.assert_allclose(channels.compute(), [[0, 1, 2, 3],
                                                         [0, 1, 2, 3],
                                                         [0, 1, 2, 3]])
         assert channels.dtype == int
+
+    def test_colorize_no_interpolation(self, mono_inc_colormap):
+        """Test colorize."""
+        data = np.array([1, 2, 3, 4])
+
+        channels = mono_inc_colormap.colorize(data)
+        for i in range(3):
+            np.testing.assert_allclose(channels[i],
+                                       mono_inc_colormap.colors[:, i],
+                                       atol=0.001)
+
+    def test_colorize_with_interpolation(self, mono_inc_colormap):
+        """Test colorize."""
+        data = np.array([1.5, 2.5, 3.5, 4])
+
+        expected_channels = [np.array([0.22178232, 0.61069262, 0.50011605, 0.]),
+                             np.array([1.08365532, 0.94644083, 0.50000605, 0.]),
+                             np.array([0.49104964, 1.20509947, 0.49989589, 0.])]
+
+        channels = mono_inc_colormap.colorize(data)
+        for i in range(3):
+            np.testing.assert_allclose(channels[i],
+                                       expected_channels[i],
+                                       atol=0.001)
+
+    def test_colorize_dask_with_interpolation(self, mono_inc_colormap):
+        """Test colorize dask arrays."""
+        import dask.array as da
+        data = da.from_array(np.array([[1.5, 2.5, 3.5, 4],
+                                       [1.5, 2.5, 3.5, 4],
+                                       [1.5, 2.5, 3.5, 4]]), chunks=2)
+
+        expected_channels = [np.array([[0.22178232, 0.61069262, 0.50011605, 0.],
+                                       [0.22178232, 0.61069262, 0.50011605, 0.],
+                                       [0.22178232, 0.61069262, 0.50011605, 0.]]),
+                             np.array([[1.08365532, 0.94644083, 0.50000605, 0.],
+                                       [1.08365532, 0.94644083, 0.50000605, 0.],
+                                       [1.08365532, 0.94644083, 0.50000605, 0.]]),
+                             np.array([[0.49104964, 1.20509947, 0.49989589, 0.],
+                                       [0.49104964, 1.20509947, 0.49989589, 0.],
+                                       [0.49104964, 1.20509947, 0.49989589, 0.]])]
+
+        channels = mono_inc_colormap.colorize(data)
+        for i, expected_channel in enumerate(expected_channels):
+            current_channel = channels[i, :, :]
+            assert isinstance(current_channel, da.Array)
+            np.testing.assert_allclose(current_channel.compute(),
+                                       expected_channel,
+                                       atol=0.001)
 
 
 def _assert_monotonic_values(cmap, increasing=True):

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -87,32 +87,6 @@ class TestColormapClass(unittest.TestCase):
                                         expected_channel,
                                         atol=0.001))
 
-    def test_palettize(self):
-        """Test palettize."""
-        data = np.array([1, 2, 3, 4])
-
-        channels, colors = self.colormap.palettize(data)
-        self.assertTrue(np.allclose(colors, self.colormap.colors))
-        self.assertTrue(all(channels == [0, 1, 2, 3]))
-
-        cm_ = colormap.Colormap((0, (0.0, 0.0, 0.0)),
-                                (1, (1.0, 1.0, 1.0)),
-                                (2, (2, 2, 2)),
-                                (3, (3, 3, 3)))
-
-        data = np.arange(-1, 5)
-
-        channels, colors = cm_.palettize(data)
-        self.assertTrue(np.allclose(colors, cm_.colors))
-        self.assertTrue(all(channels == [0, 0, 1, 2, 3, 3]))
-
-        data = np.arange(-1.0, 5.0)
-        data[-1] = np.nan
-
-        channels, colors = cm_.palettize(data)
-        self.assertTrue(np.allclose(colors, cm_.colors))
-        self.assertTrue(all(channels == [0, 0, 1, 2, 3, 3]))
-
     def test_palettize_dask(self):
         """Test palettize on a dask array."""
         import dask.array as da
@@ -146,8 +120,11 @@ class TestColormapClass(unittest.TestCase):
                                 (4, (0, 0, 0)))
 
         cm_.set_range(8, 0)
-        self.assertTrue(cm_.values[0] == 0)
-        self.assertTrue(cm_.values[-1] == 8)
+        assert cm_.values[0] == 8
+        assert cm_.values[-1] == 0
+        _assert_monotonic_values(cm_, increasing=False)
+        np.testing.assert_allclose(cm_.colors[0], (1.0, 1.0, 0.0))
+        np.testing.assert_allclose(cm_.colors[-1], (0.0, 0.0, 0.0))
 
     def test_reverse(self):
         """Test reverse."""
@@ -373,6 +350,21 @@ class TestColormap:
         # this should succeed
         _ = cmap1 + cmap2
 
+    def test_merge_monotonic_decreasing(self):
+        """Test that merged colormaps can be monotonically decreasing."""
+        cmap1 = colormap.Colormap(
+            colors=np.arange(5 * 3).reshape((5, 3)),
+            values=np.linspace(2, 1, 5),
+        )
+        cmap2 = colormap.Colormap(
+            colors=np.arange(5 * 3).reshape((5, 3)),
+            values=np.linspace(1, 0, 5),
+        )
+        _assert_monotonic_values(cmap1, increasing=False)
+        _assert_monotonic_values(cmap2, increasing=False)
+        # this should succeed
+        _ = cmap1 + cmap2
+
     @pytest.mark.parametrize('inplace', [False, True])
     def test_reverse(self, inplace):
         """Test colormap reverse."""
@@ -383,9 +375,9 @@ class TestColormap:
 
         cmap = colormap.Colormap(values=values, colors=colors)
         new_cmap = cmap.reverse(inplace)
-        self._assert_inplace_worked(cmap, new_cmap, inplace)
-        self._compare_reversed_colors(cmap, new_cmap, inplace, orig_colors)
-        self._assert_unchanged_values(cmap, new_cmap, inplace, orig_values)
+        _assert_inplace_worked(cmap, new_cmap, inplace)
+        _assert_reversed_colors(cmap, new_cmap, inplace, orig_colors)
+        _assert_unchanged_values(cmap, new_cmap, inplace, orig_values)
 
     @pytest.mark.parametrize(
         'new_range',
@@ -405,46 +397,84 @@ class TestColormap:
 
         cmap = colormap.Colormap(values=values, colors=colors)
         new_cmap = cmap.set_range(*new_range, inplace)
-        self._assert_inplace_worked(cmap, new_cmap, inplace)
-        self._assert_monotonic_values(cmap)
-        self._assert_monotonic_values(new_cmap)
-        self._assert_values_changed(cmap, new_cmap, inplace, orig_values)
-        if new_range[0] > new_range[1]:
-            self._compare_reversed_colors(cmap, new_cmap, inplace, orig_colors)
+        flipped_range = new_range[0] > new_range[1]
+        _assert_inplace_worked(cmap, new_cmap, inplace)
+        _assert_monotonic_values(cmap, increasing=not inplace or not flipped_range)
+        _assert_monotonic_values(new_cmap, increasing=not flipped_range)
+        _assert_values_changed(cmap, new_cmap, inplace, orig_values)
+        _assert_unchanged_colors(cmap, new_cmap, orig_colors)
 
-    @staticmethod
-    def _assert_monotonic_values(cmap):
-        np.testing.assert_allclose(np.diff(cmap.values) > 0, True)
+    def test_palettize(self):
+        """Test palettize."""
+        data = np.array([1, 2, 3, 4])
+        cm_ = colormap.Colormap((1, (1.0, 1.0, 0.0)),
+                                (2, (0.0, 1.0, 1.0)),
+                                (3, (1, 1, 1)),
+                                (4, (0, 0, 0)))
 
-    @staticmethod
-    def _assert_unchanged_values(cmap, new_cmap, inplace, orig_values):
-        if inplace:
-            np.testing.assert_allclose(cmap.values, orig_values)
-        else:
-            np.testing.assert_allclose(cmap.values, orig_values)
-            np.testing.assert_allclose(new_cmap.values, orig_values)
+        channels, colors = cm_.palettize(data)
+        np.testing.assert_allclose(colors, cm_.colors)
+        assert all(channels == [0, 1, 2, 3])
 
-    @staticmethod
-    def _compare_reversed_colors(cmap, new_cmap, inplace, orig_colors):
-        if inplace:
-            assert cmap is new_cmap
-            np.testing.assert_allclose(cmap.colors, orig_colors[::-1])
-        else:
-            assert cmap is not new_cmap
-            np.testing.assert_allclose(cmap.colors, orig_colors)
-            np.testing.assert_allclose(new_cmap.colors, orig_colors[::-1])
+        cm_ = colormap.Colormap((0, (0.0, 0.0, 0.0)),
+                                (1, (1.0, 1.0, 1.0)),
+                                (2, (2, 2, 2)),
+                                (3, (3, 3, 3)))
 
-    @staticmethod
-    def _assert_values_changed(cmap, new_cmap, inplace, orig_values):
-        assert not np.allclose(new_cmap.values, orig_values)
-        if not inplace:
-            np.testing.assert_allclose(cmap.values, orig_values)
-        else:
-            assert not np.allclose(cmap.values, orig_values)
+        data = np.arange(-1, 5)
 
-    @staticmethod
-    def _assert_inplace_worked(cmap, new_cmap, inplace):
-        if not inplace:
-            assert new_cmap is not cmap
-        else:
-            assert new_cmap is cmap
+        channels, colors = cm_.palettize(data)
+        np.testing.assert_allclose(colors, cm_.colors)
+        assert all(channels == [0, 0, 1, 2, 3, 3])
+
+        data = np.arange(-1.0, 5.0)
+        data[-1] = np.nan
+
+        channels, colors = cm_.palettize(data)
+        np.testing.assert_allclose(colors, cm_.colors)
+        assert all(channels == [0, 0, 1, 2, 3, 3])
+
+
+def _assert_monotonic_values(cmap, increasing=True):
+    delta = np.diff(cmap.values)
+    np.testing.assert_allclose(delta > 0, increasing)
+
+
+def _assert_unchanged_values(cmap, new_cmap, inplace, orig_values):
+    if inplace:
+        assert cmap is new_cmap
+        np.testing.assert_allclose(cmap.values, orig_values)
+    else:
+        assert cmap is not new_cmap
+        np.testing.assert_allclose(cmap.values, orig_values)
+        np.testing.assert_allclose(new_cmap.values, orig_values)
+
+
+def _assert_unchanged_colors(cmap, new_cmap, orig_colors):
+    np.testing.assert_allclose(cmap.colors, orig_colors)
+    np.testing.assert_allclose(new_cmap.colors, orig_colors)
+
+
+def _assert_reversed_colors(cmap, new_cmap, inplace, orig_colors):
+    if inplace:
+        assert cmap is new_cmap
+        np.testing.assert_allclose(cmap.colors, orig_colors[::-1])
+    else:
+        assert cmap is not new_cmap
+        np.testing.assert_allclose(cmap.colors, orig_colors)
+        np.testing.assert_allclose(new_cmap.colors, orig_colors[::-1])
+
+
+def _assert_values_changed(cmap, new_cmap, inplace, orig_values):
+    assert not np.allclose(new_cmap.values, orig_values)
+    if not inplace:
+        np.testing.assert_allclose(cmap.values, orig_values)
+    else:
+        assert not np.allclose(cmap.values, orig_values)
+
+
+def _assert_inplace_worked(cmap, new_cmap, inplace):
+    if not inplace:
+        assert new_cmap is not cmap
+    else:
+        assert new_cmap is cmap


### PR DESCRIPTION
As part of my work with #99 and as a change to what I did in #82, this PR changes `set_range` so a flipped range is preserved in the `.values` of the Colormap. Previously (as implemented in #82) this would flip the colors (and previous to that it would ignore the flipped limits and assume you meant them to be min/max). The flipped colors from `set_range` was causing issues for me in Satpy since I was specifying a Colormap by a filename and any changes to the colors was not preserved. Using `enhancement_history` in #99 I am able to easily store the range of the Colormap, but in a colorize operation the original colormap is lost (encoded in the data that is now RGB/A). If I was to use flipped limits in my colorize enhancement and then reuse the `enhancement_history` later on with the original colormap file, the two are no longer in sync. By that I mean that the enhancement_history is related to the flipped colors, not the original colors in the colormap.

In this PR I update `set_range` so flipped limits are preserved which can result in monotonically decreasing `.values` of the colormap. I added tests for the basic usages of this, but also for colorize and palettize with colormaps with monotonically decreasing values. This required handling the `values` in a special way with colorize and palettize. I think I've made the most logical decision on implementing these. For example, palettize was updated to make out of range colors clip to the last color of the colormap in both flipped or unflipped values. It also defines the bin ranges of palettize in the positive/increasing direction so flipping the colormap's ranges and colors should produce the same index results.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
