### PR TITLE
Add to_csv/from_csv to Colormap

### DIFF
--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -354,7 +354,11 @@ class Colormap(object):
                    (self.colors.max() - self.colors.min())) * 255)
         return dict(zip(self.values, tuple(map(tuple, colors))))
 
-    def to_csv(self, filename: Optional[str] = None) -> Optional[str]:
+    def to_csv(
+            self,
+            filename: Optional[str] = None,
+            color_scale: Number = 255,
+    ) -> Optional[str]:
         """Save Colormap to a comma-separated text file or string.
 
         The CSV data will have 4 to 5 columns for each row where each
@@ -367,13 +371,16 @@ class Colormap(object):
         integer value.
 
         Args:
-            filename (str, optional): The filename of the CSV file to save to.
+            filename: The filename of the CSV file to save to.
                 If not provided or None a string is returned with the contents.
+            color_scale: Scale colors by this factor before converting to a
+                CSV. Colors are stored in the Colormap in a 0 to 1 range.
+                Defaults to 255.
 
         """
         with _file_or_stringio(filename) as csv_file:
             for value, color in zip(self.values, self.colors):
-                csv_file.write(",".join(["{:0.6f}".format(value)] + [str(int(x * 255)) for x in color]) + "\n")
+                csv_file.write(",".join(["{:0.6f}".format(value)] + [str(int(x * color_scale)) for x in color]) + "\n")
         if isinstance(csv_file, StringIO):
             return csv_file.getvalue()
 
@@ -382,7 +389,7 @@ class Colormap(object):
             cls,
             filename_or_string: str,
             colormap_mode: Optional[str] = None,
-            color_scale: Number = 255
+            color_scale: Number = 255,
     ):
         """Create Colormap from a comma-separated or binary file of colormap data.
 

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -375,12 +375,16 @@ class Colormap(object):
                 If not provided or None a string is returned with the contents.
             color_scale: Scale colors by this factor before converting to a
                 CSV. Colors are stored in the Colormap in a 0 to 1 range.
-                Defaults to 255.
+                Defaults to 255. If not equal to 1 values are converted to
+                integers too.
 
         """
         with _file_or_stringio(filename) as csv_file:
             for value, color in zip(self.values, self.colors):
-                csv_file.write(",".join(["{:0.6f}".format(value)] + [str(int(x * color_scale)) for x in color]) + "\n")
+                scaled_color = [x * color_scale for x in color]
+                if color_scale != 1.0:
+                    scaled_color = [int(x) for x in scaled_color]
+                csv_file.write(",".join(["{:0.6f}".format(value)] + [str(x) for x in scaled_color]) + "\n")
         if isinstance(csv_file, StringIO):
             return csv_file.getvalue()
 

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -21,9 +21,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Test colormap.py."""
 
+import os
+import contextlib
 import unittest
 from trollimage import colormap
 import numpy as np
+from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -480,6 +483,56 @@ class TestColormap:
                                        expected_channel,
                                        atol=0.001)
 
+
+@contextlib.contextmanager
+def closed_named_temp_file(**kwargs):
+    """Named temporary file context manager that closes the file after creation.
+
+    This helps with Windows systems which can get upset with opening or
+    deleting a file that is already open.
+
+    """
+    try:
+        with NamedTemporaryFile(delete=False, **kwargs) as tmp_cmap:
+            yield tmp_cmap.name
+    finally:
+        os.remove(tmp_cmap.name)
+
+
+def _write_cmap_to_file(cmap_filename, cmap_data):
+    ext = os.path.splitext(cmap_filename)[1]
+    if ext in (".npy",):
+        np.save(cmap_filename, cmap_data)
+    elif ext in (".npz",):
+        np.savez(cmap_filename, cmap_data)
+    else:
+        np.savetxt(cmap_filename, cmap_data, delimiter=",")
+
+
+def _generate_cmap_test_data(color_scale, colormap_mode):
+    cmap_data = np.array([
+        [1, 0, 0],
+        [1, 1, 0],
+        [1, 1, 1],
+        [0, 0, 1],
+    ], dtype=np.float64)
+    if len(colormap_mode) != 3:
+        _cmap_data = cmap_data
+        cmap_data = np.empty((cmap_data.shape[0], len(colormap_mode)),
+                             dtype=np.float64)
+        if colormap_mode.startswith("V") or colormap_mode.endswith("A"):
+            cmap_data[:, 0] = np.array([128, 130, 132, 134]) / 255.0
+            cmap_data[:, -3:] = _cmap_data
+        if colormap_mode.startswith("V") and colormap_mode.endswith("A"):
+            cmap_data[:, 1] = np.array([128, 130, 132, 134]) / 255.0
+    if color_scale is None or color_scale == 255:
+        cmap_data = (cmap_data * 255).astype(np.uint8)
+    return cmap_data
+
+
+class TestFromFileCreation:
+    """Tests for loading Colormaps from files."""
+
     @pytest.mark.parametrize("csv_filename", [None, "test.cmap"])
     @pytest.mark.parametrize("new_range", [None, (25.0, 75.0)])
     def test_csv_roundtrip(self, tmp_path, csv_filename, new_range):
@@ -491,13 +544,88 @@ class TestColormap:
             csv_filename = str(tmp_path / csv_filename)
             res = orig_cmap.to_csv(csv_filename)
             assert res is None
-            new_cmap = colormap.Colormap.from_csv(csv_filename)
+            new_cmap = colormap.Colormap.from_file(csv_filename)
         else:
             res = orig_cmap.to_csv(None)
             assert isinstance(res, str)
-            new_cmap = colormap.Colormap.from_csv(res)
+            new_cmap = colormap.Colormap.from_file(res)
         np.testing.assert_allclose(orig_cmap.values, new_cmap.values)
         np.testing.assert_allclose(orig_cmap.colors, new_cmap.colors)
+
+    @pytest.mark.parametrize("color_scale", [None, 1.0])
+    @pytest.mark.parametrize("colormap_mode", ["RGB", "VRGB", "VRGBA"])
+    @pytest.mark.parametrize("filename_suffix", [".npy", ".npz", ".csv"])
+    def test_cmap_from_file(self, color_scale, colormap_mode, filename_suffix):
+        """Test that colormaps can be loaded from a binary or CSV file."""
+        # create the colormap file on disk
+        with closed_named_temp_file(suffix=filename_suffix) as cmap_filename:
+            cmap_data = _generate_cmap_test_data(color_scale, colormap_mode)
+            _write_cmap_to_file(cmap_filename, cmap_data)
+
+            unset_first_value = 128.0 / 255.0 if colormap_mode.startswith("V") else 0.0
+            unset_last_value = 134.0 / 255.0 if colormap_mode.startswith("V") else 1.0
+            if (color_scale is None or color_scale == 255) and colormap_mode.startswith("V"):
+                unset_first_value *= 255
+                unset_last_value *= 255
+
+            first_color = [1.0, 0.0, 0.0]
+            if colormap_mode == "VRGBA":
+                first_color = [128.0 / 255.0] + first_color
+
+            kwargs1 = {}
+            if color_scale is not None:
+                kwargs1["color_scale"] = color_scale
+
+            cmap = colormap.Colormap.from_file(cmap_filename, **kwargs1)
+            assert cmap.colors.shape[0] == 4
+            np.testing.assert_equal(cmap.colors[0], first_color)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == unset_first_value
+            assert cmap.values[-1] == unset_last_value
+
+    def test_cmap_vrgb_as_rgba(self):
+        """Test that data created as VRGB still reads as RGBA."""
+        with closed_named_temp_file(suffix=".npy") as cmap_filename:
+            cmap_data = _generate_cmap_test_data(None, "VRGB")
+            np.save(cmap_filename, cmap_data)
+            cmap = colormap.Colormap.from_file(cmap_filename, colormap_mode="RGBA")
+            assert cmap.colors.shape[0] == 4
+            assert cmap.colors.shape[1] == 4  # RGBA
+            np.testing.assert_equal(cmap.colors[0], [128 / 255., 1.0, 0, 0])
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 0
+            assert cmap.values[-1] == 1.0
+
+    @pytest.mark.parametrize(
+        ("real_mode", "forced_mode"),
+        [
+            ("VRGBA", "RGBA"),
+            ("VRGBA", "VRGB"),
+            ("RGBA", "RGB"),
+        ]
+    )
+    @pytest.mark.parametrize("filename_suffix", [".npy", ".csv"])
+    def test_cmap_bad_mode(self, real_mode, forced_mode, filename_suffix):
+        """Test that reading colormaps with the wrong mode fails."""
+        with closed_named_temp_file(suffix=filename_suffix) as cmap_filename:
+            cmap_data = _generate_cmap_test_data(None, real_mode)
+            _write_cmap_to_file(cmap_filename, cmap_data)
+            # Force colormap_mode VRGBA to RGBA and we should see an exception
+            with pytest.raises(ValueError):
+                colormap.Colormap.from_file(cmap_filename, colormap_mode=forced_mode)
+
+    def test_cmap_from_file_bad_shape(self):
+        """Test that unknown array shape causes an error."""
+        with closed_named_temp_file(suffix='.npy') as cmap_filename:
+            np.save(cmap_filename, np.array([
+                [0],
+                [64],
+                [128],
+                [255],
+            ]))
+
+            with pytest.raises(ValueError):
+                colormap.Colormap.from_file(cmap_filename)
 
 
 def _assert_monotonic_values(cmap, increasing=True):

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -480,6 +480,25 @@ class TestColormap:
                                        expected_channel,
                                        atol=0.001)
 
+    @pytest.mark.parametrize("csv_filename", [None, "test.cmap"])
+    @pytest.mark.parametrize("new_range", [None, (25.0, 75.0)])
+    def test_csv_roundtrip(self, tmp_path, csv_filename, new_range):
+        """Test saving and loading a Colormap from a CSV file."""
+        orig_cmap = colormap.brbg
+        if new_range is not None:
+            orig_cmap = orig_cmap.set_range(*new_range, inplace=False)
+        if isinstance(csv_filename, str):
+            csv_filename = str(tmp_path / csv_filename)
+            res = orig_cmap.to_csv(csv_filename)
+            assert res is None
+            new_cmap = colormap.Colormap.from_csv(csv_filename)
+        else:
+            res = orig_cmap.to_csv(None)
+            assert isinstance(res, str)
+            new_cmap = colormap.Colormap.from_csv(res)
+        np.testing.assert_allclose(orig_cmap.values, new_cmap.values)
+        np.testing.assert_allclose(orig_cmap.colors, new_cmap.colors)
+
 
 def _assert_monotonic_values(cmap, increasing=True):
     delta = np.diff(cmap.values)

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -535,20 +535,21 @@ class TestFromFileCreation:
 
     @pytest.mark.parametrize("csv_filename", [None, "test.cmap"])
     @pytest.mark.parametrize("new_range", [None, (25.0, 75.0)])
-    def test_csv_roundtrip(self, tmp_path, csv_filename, new_range):
+    @pytest.mark.parametrize("color_scale", [1.0, 255, 65535])
+    def test_csv_roundtrip(self, tmp_path, csv_filename, new_range, color_scale):
         """Test saving and loading a Colormap from a CSV file."""
         orig_cmap = colormap.brbg
         if new_range is not None:
             orig_cmap = orig_cmap.set_range(*new_range, inplace=False)
         if isinstance(csv_filename, str):
             csv_filename = str(tmp_path / csv_filename)
-            res = orig_cmap.to_csv(csv_filename)
+            res = orig_cmap.to_csv(csv_filename, color_scale=color_scale)
             assert res is None
-            new_cmap = colormap.Colormap.from_file(csv_filename)
+            new_cmap = colormap.Colormap.from_file(csv_filename, color_scale=color_scale)
         else:
-            res = orig_cmap.to_csv(None)
+            res = orig_cmap.to_csv(None, color_scale=color_scale)
             assert isinstance(res, str)
-            new_cmap = colormap.Colormap.from_file(res)
+            new_cmap = colormap.Colormap.from_file(res, color_scale=color_scale)
         np.testing.assert_allclose(orig_cmap.values, new_cmap.values)
         np.testing.assert_allclose(orig_cmap.colors, new_cmap.colors)
 


### PR DESCRIPTION
This is needed by #99 so that a colormap can be fully reconstructed with minimal information. This is a fairly useful feature by itself so I thought I'd make a separate PR for it. This is not as flexible as the loading logic in Satpy for colormaps, but I'm not sure if it should be. It would require extra keyword arguments like `colormap_mode`, etc. Maybe it should be added?

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
