### PR TITLE
Fix geotiff scale/offset failing for non-linear enhancements

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2193,10 +2193,10 @@ class TestXRImagePalettize:
                 np.testing.assert_allclose(new_brbg.colors, loaded_brbg.colors)
 
 
-class TestXRImageSaveScaleOffset(unittest.TestCase):
+class TestXRImageSaveScaleOffset:
     """Test case for saving an image with scale and offset tags."""
 
-    def setUp(self) -> None:
+    def setup_method(self) -> None:
         """Set up the test case."""
         from trollimage import xrimage
         data = xr.DataArray(np.arange(25).reshape(5, 5, 1), dims=[
@@ -2213,6 +2213,12 @@ class TestXRImageSaveScaleOffset(unittest.TestCase):
             self._save_and_check_tags(
                 expected_tags,
                 include_scale_offset_tags=True)
+
+    def test_gamma_geotiff_scale_offset(self, tmp_path):
+        """Test that saving gamma-enhanced data to a geotiff doesn't fail."""
+        self.img.gamma(.5)
+        out_fn = str(tmp_path / "test.tif")
+        self.img.save(out_fn, scale_offset_tags=("scale", "offset"))
 
     def _save_and_check_tags(self, expected_tags, **kwargs):
         with NamedTemporaryFile(suffix='.tif') as tmp:

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -599,9 +599,7 @@ class XRImage(object):
         if colormap_tag and enhancement_colormap is not None:
             tags[colormap_tag] = enhancement_colormap.to_csv()
         if scale_offset_tags:
-            scale_label, offset_label = scale_offset_tags
-            scale, offset = self.get_scaling_from_history(data.attrs.get('enhancement_history', []))
-            tags[scale_label], tags[offset_label] = invert_scale_offset(scale, offset)
+            self._add_scale_offset_to_tags(scale_offset_tags, data, tags)
 
         # If we are changing the driver then use appropriate kwargs
         if driver == 'COG':
@@ -698,6 +696,15 @@ class XRImage(object):
         if compute:
             return delay.compute()
         return delay
+
+    def _add_scale_offset_to_tags(self, scale_offset_tags, data_arr, tags):
+        scale_label, offset_label = scale_offset_tags
+        try:
+            scale, offset = self.get_scaling_from_history(data_arr.attrs.get('enhancement_history', []))
+        except NotImplementedError:
+            logger.debug("Ignoring scale/offset tags for non-scaling enhancement operations")
+        else:
+            tags[scale_label], tags[offset_label] = invert_scale_offset(scale, offset)
 
     def get_scaling_from_history(self, history=None):
         """Merge the scales and offsets from the history.


### PR DESCRIPTION
The geotiff `scale_offset_tags` looks through the enhancement_history and gathers all scale/offset information. If an enhancement *doesn't* have those then the entire saving operation fails. This makes batch processing difficult where I would like all datasets that can have scale/offset tags to have them, but any that don't to not fail but still be produced.

This PR fixes this by turning the error into a DEBUG logger message. I would say it could be a warning, but I'm not sure how I feel about that since it is the desired output I want. Additionally, I'm not sure I like the cleanliness of my code in this, but couldn't think of anything better.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)

