### PR TITLE
Set scale/offset tags to (NaN, NaN) for incompatible enhancements

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2202,6 +2202,9 @@ class TestXRImageSaveScaleOffset:
         data = xr.DataArray(np.arange(25).reshape(5, 5, 1), dims=[
             'y', 'x', 'bands'], coords={'bands': ['L']})
         self.img = xrimage.XRImage(data)
+        rgb_data = xr.DataArray(np.arange(3 * 25).reshape(5, 5, 3), dims=[
+            'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
+        self.rgb_img = xrimage.XRImage(rgb_data)
 
     @pytest.mark.skipif(sys.platform.startswith('win'), reason="'NamedTemporaryFile' not supported on Windows")
     def test_save_scale_offset(self):
@@ -2215,10 +2218,20 @@ class TestXRImageSaveScaleOffset:
                 include_scale_offset_tags=True)
 
     def test_gamma_geotiff_scale_offset(self, tmp_path):
-        """Test that saving gamma-enhanced data to a geotiff doesn't fail."""
+        """Test that saving gamma-enhanced data to a geotiff with scale/offset tags doesn't fail."""
         self.img.gamma(.5)
         out_fn = str(tmp_path / "test.tif")
         self.img.save(out_fn, scale_offset_tags=("scale", "offset"))
+
+    def test_rgb_geotiff_scale_offset(self, tmp_path):
+        """Test that saving RGB data to a geotiff with scale/offset tags doesn't fail."""
+        self.rgb_img.stretch(
+            stretch="crude",
+            min_stretch=[-25, -40, 243],
+            max_stretch=[0, 5, 208]
+        )
+        out_fn = str(tmp_path / "test.tif")
+        self.rgb_img.save(out_fn, scale_offset_tags=("scale", "offset"))
 
     def _save_and_check_tags(self, expected_tags, **kwargs):
         with NamedTemporaryFile(suffix='.tif') as tmp:

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2222,6 +2222,9 @@ class TestXRImageSaveScaleOffset:
         self.img.gamma(.5)
         out_fn = str(tmp_path / "test.tif")
         self.img.save(out_fn, scale_offset_tags=("scale", "offset"))
+        with rio.open(out_fn, "r") as ds:
+            assert np.isnan(float(ds.tags()["scale"]))
+            assert np.isnan(float(ds.tags()["offset"]))
 
     def test_rgb_geotiff_scale_offset(self, tmp_path):
         """Test that saving RGB data to a geotiff with scale/offset tags doesn't fail."""
@@ -2232,6 +2235,9 @@ class TestXRImageSaveScaleOffset:
         )
         out_fn = str(tmp_path / "test.tif")
         self.rgb_img.save(out_fn, scale_offset_tags=("scale", "offset"))
+        with rio.open(out_fn, "r") as ds:
+            assert np.isnan(float(ds.tags()["scale"]))
+            assert np.isnan(float(ds.tags()["offset"]))
 
     def _save_and_check_tags(self, expected_tags, **kwargs):
         with NamedTemporaryFile(suffix='.tif') as tmp:

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -508,14 +508,12 @@ class XRImage:
                 If set to a ``(str, str)`` tuple, scale and offset will be
                 stored in GDALMetaData tags.  Those can then be used to
                 retrieve the original data values from pixel values.
-                Scale and offset will not be saved for images that had
+                Scale and offset will be set to (NaN, NaN) for images that had
                 non-linear enhancements applied (ex. gamma) as they can't be
                 represented by a simple scale and offset. Scale and offset
-                are also not saved for multi-band images (ex. RGB) as storing
-                multiple values in a single GDALMetaData tag is not currently
-                supported. These cases are ignored instead of raising an error
-                to simplify batch processing that may be saving multiple images
-                with a single set of keyword arguments.
+                are also saved as (NaN, NaN) for multi-band images (ex. RGB)
+                as storing multiple values in a single GDALMetaData tag is not
+                currently supported.
             colormap_tag (str or None):
                 If set and the image was colorized or palettized, a tag will
                 be added with this name with the value of a comma-separated

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -705,7 +705,9 @@ class XRImage(object):
         except NotImplementedError:
             logger.debug("Ignoring scale/offset tags for non-scaling enhancement operations")
         else:
-            if not isinstance(scale, numbers.Number) or not isinstance(offset, numbers.Number):
+            scale_is_not_scalar = not isinstance(scale, numbers.Number) and len(scale) != 1
+            offset_is_not_scalar = not isinstance(offset, numbers.Number) and len(offset) != 1
+            if scale_is_not_scalar or offset_is_not_scalar:
                 logger.debug("Skipping multi-band scale/offset tags which "
                              "can't be saved to geotiff.")
                 return

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -33,6 +33,7 @@ chunks can be saved in parallel.
 """
 
 import logging
+import numbers
 import os
 import threading
 import warnings
@@ -704,6 +705,10 @@ class XRImage(object):
         except NotImplementedError:
             logger.debug("Ignoring scale/offset tags for non-scaling enhancement operations")
         else:
+            if not isinstance(scale, numbers.Number) or not isinstance(offset, numbers.Number):
+                logger.debug("Skipping multi-band scale/offset tags which "
+                             "can't be saved to geotiff.")
+                return
             tags[scale_label], tags[offset_label] = invert_scale_offset(scale, offset)
 
     def get_scaling_from_history(self, history=None):

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -308,7 +308,7 @@ def delayed_pil_save(img, *args, **kwargs):
         raise
 
 
-class XRImage(object):
+class XRImage:
     """Image class using an :class:`xarray.DataArray` as internal storage.
 
     It can be saved to a variety of image formats, but if Rasterio is
@@ -708,18 +708,8 @@ class XRImage(object):
 
     def _add_scale_offset_to_tags(self, scale_offset_tags, data_arr, tags):
         scale_label, offset_label = scale_offset_tags
-        try:
-            scale, offset = self.get_scaling_from_history(data_arr.attrs.get('enhancement_history', []))
-        except NotImplementedError:
-            logger.info("Ignoring scale/offset tags for non-scaling enhancement operations")
-        else:
-            scale_is_not_scalar = not isinstance(scale, numbers.Number) and len(scale) != 1
-            offset_is_not_scalar = not isinstance(offset, numbers.Number) and len(offset) != 1
-            if scale_is_not_scalar or offset_is_not_scalar:
-                logger.info("Skipping multi-band scale/offset tags which "
-                            "can't be saved to geotiff.")
-                return
-            tags[scale_label], tags[offset_label] = invert_scale_offset(scale, offset)
+        scale, offset = self.get_scaling_from_history(data_arr.attrs.get('enhancement_history', []))
+        tags[scale_label], tags[offset_label] = invert_scale_offset(scale, offset)
 
     def get_scaling_from_history(self, history=None):
         """Merge the scales and offsets from the history.
@@ -732,8 +722,18 @@ class XRImage(object):
         try:
             scaling = [(item['scale'], item['offset']) for item in history]
         except KeyError as err:
-            raise NotImplementedError('Can only get combine scaling from a list of scaling operations: %s' % str(err))
-        return combine_scales_offsets(*scaling)
+            logger.debug("Can only get combine scaling from a list of linear "
+                         f"scaling operations: {err}. Setting scale and offset "
+                         "to (NaN, NaN).")
+            return np.nan, np.nan
+        scale, offset = combine_scales_offsets(*scaling)
+        scale_is_not_scalar = not isinstance(scale, numbers.Number) and len(scale) != 1
+        offset_is_not_scalar = not isinstance(offset, numbers.Number) and len(offset) != 1
+        if scale_is_not_scalar or offset_is_not_scalar:
+            logger.debug("Multi-band scale/offset tags can't be saved to "
+                         "geotiff. Setting scale and offset to (NaN, NaN).")
+            return np.nan, np.nan
+        return scale, offset
 
     @delayed(nout=1, pure=True)
     def _delayed_apply_pil(self, fun, pil_image, fun_args, fun_kwargs,


### PR DESCRIPTION
Similar to #103, I want to batch create a lot of geotiffs and some of them might be RGBs that have had a linear enhancement applied to them. However, we can't (currently) save a multi-element tag (a list) to the geotiff metadata. This PR changes the behavior, including what was done in #103, to log a debug message but then set the scale and offset metadata tags to NaN. This should be fine for Python users as `float("nan")` (the string version of the number that rasterio saves) will convert to NaN properly.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
