### PR TITLE
Fix typo in rasterio AreaDefinition handling

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -14,6 +14,8 @@ dependencies:
   - codecov
   - rasterio
   - libtiff
+  - pyproj
+  - pyresample
   - pytest
   - pytest-cov
   - fsspec

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setup(name="trollimage",
           'geotiff': ['rasterio>=1.0'],
           'xarray': ['xarray', 'dask[array]'],
       },
-      tests_require=['xarray', 'dask[array]'],
+      tests_require=['xarray', 'dask[array]', 'pyproj', 'pyresample'],
       )

--- a/trollimage/_xrimage_rasterio.py
+++ b/trollimage/_xrimage_rasterio.py
@@ -20,12 +20,8 @@ from contextlib import suppress
 
 import dask.array as da
 
-try:
-    import rasterio
-    from rasterio.enums import Resampling
-except ImportError:
-    rasterio = None
-
+import rasterio
+from rasterio.enums import Resampling
 from rasterio.windows import Window
 
 logger = logging.getLogger(__name__)

--- a/trollimage/_xrimage_rasterio.py
+++ b/trollimage/_xrimage_rasterio.py
@@ -51,7 +51,7 @@ def get_data_arr_crs_transform_gcps(data_arr):
     gcps = None
 
     try:
-        area = data_arr.attr["area"]
+        area = data_arr.attrs["area"]
         if rasterio.__gdal_version__ >= '3':
             wkt_version = 'WKT2_2018'
         else:

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1133,7 +1133,7 @@ class TestXRImage:
     def test_save_geotiff_int_no_gcp_swath(self):
         """Test saving geotiffs when input data whose SwathDefinition has no GCPs.
 
-        If shouldn't fail, but it also shouldn't have a non-default CRS or transform.
+        If shouldn't fail, but it also shouldn't have a non-default transform.
 
         """
         from pyresample import SwathDefinition
@@ -1155,7 +1155,6 @@ class TestXRImage:
         with NamedTemporaryFile(suffix='.tif') as tmp:
             img.save(tmp.name)
             with rio.open(tmp.name) as f:
-                assert f.crs.to_epsg() == 4326  # default
                 assert f.transform.a == 1.0
                 assert f.transform.b == 0.0
                 assert f.transform.c == 0.0

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1106,10 +1106,7 @@ class TestXRImage:
             delay[1].close()
 
         # GCPs
-        class FakeSwathDefinition():
-            def __init__(self, lons, lats):
-                self.lons = lons
-                self.lats = lats
+        from pyresample import SwathDefinition
 
         gcps = [GroundControlPoint(1, 1, 100.0, 1000.0, z=0.0),
                 GroundControlPoint(2, 3, 400.0, 2000.0, z=0.0)]
@@ -1124,11 +1121,12 @@ class TestXRImage:
                             dims=['y', 'x'],
                             attrs={'gcps': gcps,
                                    'crs': crs})
+        swath_def = SwathDefinition(lons, lats)
 
         data = xr.DataArray(da.from_array(np.arange(75).reshape(5, 5, 3), chunks=5),
                             dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']},
-                            attrs={'area': FakeSwathDefinition(lons, lats)})
+                            attrs={'area': swath_def})
         img = xrimage.XRImage(data)
         with NamedTemporaryFile(suffix='.tif') as tmp:
             img.save(tmp.name)

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1073,6 +1073,8 @@ class TestXRImage:
             np.testing.assert_allclose(file_data[2], exp[:, :, 2])
             np.testing.assert_allclose(file_data[3], 255)
 
+    @pytest.mark.skipif(sys.platform.startswith('win'),
+                        reason="'NamedTemporaryFile' not supported on Windows")
     def test_save_geotiff_delayed(self):
         """Test saving a geotiff but not computing the result immediately."""
         data = xr.DataArray(np.arange(75).reshape(5, 5, 3), dims=[
@@ -1087,6 +1089,8 @@ class TestXRImage:
             da.store(*delay)
             delay[1].close()
 
+    @pytest.mark.skipif(sys.platform.startswith('win'),
+                        reason="'NamedTemporaryFile' not supported on Windows")
     def test_save_geotiff_int_gcps(self):
         """Test saving geotiffs when input data is int and has GCPs."""
         from rasterio.control import GroundControlPoint
@@ -1124,6 +1128,8 @@ class TestXRImage:
                 assert ref.z == val.z
             assert crs == fcrs
 
+    @pytest.mark.skipif(sys.platform.startswith('win'),
+                        reason="'NamedTemporaryFile' not supported on Windows")
     def test_save_geotiff_int_rio_colormap(self):
         """Test saving geotiffs when input data is int and a rasterio colormap is provided."""
         exp_cmap = {i: (i, 255 - i, i, 255) for i in range(256)}
@@ -1141,6 +1147,8 @@ class TestXRImage:
             np.testing.assert_allclose(file_data[0], exp[:, :, 0])
             assert cmap == exp_cmap
 
+    @pytest.mark.skipif(sys.platform.startswith('win'),
+                        reason="'NamedTemporaryFile' not supported on Windows")
     def test_save_geotiff_int_with_fill(self):
         """Test saving geotiffs when input data is int and a fill value is specified."""
         data = np.arange(75).reshape(5, 5, 3)
@@ -1165,6 +1173,8 @@ class TestXRImage:
             np.testing.assert_allclose(file_data[1], exp[:, :, 1])
             np.testing.assert_allclose(file_data[2], exp[:, :, 2])
 
+    @pytest.mark.skipif(sys.platform.startswith('win'),
+                        reason="'NamedTemporaryFile' not supported on Windows")
     def test_save_geotiff_int_with_fill_and_alpha(self):
         """Test saving int geotiffs with a fill value and input alpha band."""
         data = np.arange(75).reshape(5, 5, 3)

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1197,6 +1197,8 @@ class TestXRImage:
             np.testing.assert_allclose(file_data[2], exp[:, :, 2])
             np.testing.assert_allclose(file_data[3], exp_alpha)
 
+    @pytest.mark.skipif(sys.platform.startswith('win'),
+                        reason="'NamedTemporaryFile' not supported on Windows")
     def test_save_geotiff_int_with_area_def(self):
         """Test saving a integer image with an AreaDefinition."""
         from pyproj import CRS


### PR DESCRIPTION
I had a typo in #107 but the tests didn't catch it. This fixes the typo and adds a test. To be safe, I've added pyproj and pyresample as test dependencies rather than try to make a class that faked the interface.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
