### PR TITLE
Fix XRImage.colorize to mask integer data with _FillValue

### DIFF
--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1263,7 +1263,12 @@ class XRImage:
         """Colorize the current image using ``colormap``.
 
         Convert a greyscale image (mode "L" or "LA") to a color image (mode
-        "RGB" or "RGBA") by applying a colormap.
+        "RGB" or "RGBA") by applying a colormap. If floating point data being
+        colorized contains NaNs then the result will also contain NaNs instead
+        of a color from the colormap. Integer data that includes
+        a ``.attrs['_FillValue']`` will be converted to a floating point array
+        and values equal to ``_FillValue`` replaced with NaN before being
+        colorized.
 
         To create a color image in mode "P" or "PA", use
         :meth:`~XRImage.palettize`.


### PR DESCRIPTION
 - [x] Closes https://github.com/ssec/polar2grid/issues/545 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
