### PR TITLE
Add readthedocs config file to force newer dependencies

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.10"
+sphinx:
+  configuration: doc/conf.py
+python:
+  install:
+    - requirements: rtd_requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -3,3 +3,6 @@ rasterio
 xarray
 dask[array]
 docutils<0.18
+sphinx>=5,<6
+sphinx-rtd-theme>=1.1.0,<2.0
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ universal=1
 
 [flake8]
 max-line-length = 120
+exclude = 
+    doc/conf.py
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
It was pointed out on slack that there were some formatting issues in the installation instructions (the last `pip install -e .` wasn't showing up). It looks like readthedocs defaults to using really old versions for projects created before 2020.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
