### PR TITLE
Refactor colormap creation

### DIFF
--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -485,7 +485,7 @@ class Colormap(object):
     @classmethod
     def from_csv(cls, path, colormap_mode=None, color_scale=255):
         """Create Colormap from CSV."""
-        cmap_data = np.loadtext(path, delimeter=",")
+        cmap_data = np.loadtxt(path, delimiter=",")
         return cls.from_ndarray(cmap_data, colormap_mode, color_scale)
 
     @classmethod
@@ -503,6 +503,8 @@ class Colormap(object):
     @classmethod
     def from_sequence_of_colors(cls, colors, values=None, color_scale=255):
         """Create Colormap from sequence of colors."""
+        # this method was moved from satpy. where it was in
+        # satpy.enhancements.create_colormap
         cmap = []
         for idx, color in enumerate(colors):
             if values is not None:
@@ -512,11 +514,13 @@ class Colormap(object):
             if color_scale != 1:
                 color = tuple(elem / float(color_scale) for elem in color)
             cmap.append((value, tuple(color)))
-        return Colormap(*cmap)
+        return cls(*cmap)
 
     @classmethod
     def from_xrda(cls, palette, dtype, info):
         """Create Colormap from xarray dataarray with metadata."""
+        # this method was moved from satpy, where it was in
+        # satpy.composites.ColormapCompositor.build_colormap
         squeezed_palette = np.asanyarray(palette).squeeze() / 255.0
         set_range = True
         if hasattr(palette, 'attrs') and 'palette_meanings' in palette.attrs:

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -409,7 +409,7 @@ class Colormap(object):
         """Create Colormap from a comma-separated or binary file of colormap data.
 
         Args:
-            filename_or_string: Filename of a binary or CSV file
+            filename: Filename of a binary or CSV file
             colormap_mode: Force the scheme of the colormap data (ex. RGBA).
                 See information below on other possible values and how they
                 are interpreted. By default this is determined based on the
@@ -448,9 +448,10 @@ class Colormap(object):
 
         To read from a string containing CSV, use :meth:`~Colormap.from_csv`.
 
-        To get a named colormap, use :meth:`~Colormap.from_name`.
+        To get a named colormap, use :meth:`~Colormap.from_name` or load the
+        colormap directly as a module attribute.
 
-        To get a colormap from an ndarray, use :meth:`~Colormap.from_ndorray`.
+        To get a colormap from an ndarray, use :meth:`~Colormap.from_ndarray`.
 
         **Color Scale**
 

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -618,7 +618,8 @@ class Colormap(object):
     @classmethod
     def from_array_with_metadata(
             cls, palette, dtype, color_scale=255,
-            valid_range=None, scale_factor=1, add_offset=0):
+            valid_range=None, scale_factor=1, add_offset=0,
+            remove_last=True):
         """Create Colormap from an array with metadata.
 
         Create a colormap from an array with associated metadata, either in
@@ -653,6 +654,9 @@ class Colormap(object):
                 scale factor to apply to the colormap
             add_offset
                 add offset to apply to the colormap
+            remove_last
+                Remove the last value if the array has no metadata associated.
+                Defaults to true for historical reasons.
 
         """
         # this method was moved from satpy, where it was in
@@ -668,8 +672,9 @@ class Colormap(object):
             # remove the last value because monkeys don't like water sprays
             # on a more serious note, I don't know why we are removing the last
             # value here, but this behaviour was copied from ancient satpy code
-            values = np.arange(squeezed_palette.shape[0]-1)
-            squeezed_palette = squeezed_palette[:-1, :]
+            values = np.arange(squeezed_palette.shape[0]-remove_last)
+            if remove_last:
+                squeezed_palette = squeezed_palette[:-remove_last, :]
 
         color_array = np.concatenate((values[:, np.newaxis], squeezed_palette), axis=1)
         colormap = cls.from_ndarray(

--- a/trollimage/image.py
+++ b/trollimage/image.py
@@ -1021,7 +1021,7 @@ class Image(object):
 
         if((not self.channels[ch_nb].mask.all()) and
                 abs(max_stretch - min_stretch) > 0):
-            stretched = self.channels[ch_nb].data.astype(np.float)
+            stretched = self.channels[ch_nb].data.astype(np.float64)
             stretched -= min_stretch
             stretched /= max_stretch - min_stretch
             self.channels[ch_nb] = np.ma.array(stretched,

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -685,17 +685,17 @@ def test_cmap_from_sequence_of_colors():
 def test_build_colormap_with_int_data_and_without_meanings():
     """Test colormap building."""
     palette = np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]])
-    cmap = colormap.Colormap.from_xrda(palette, np.uint8, {})
+    cmap = colormap.Colormap.from_array_with_metadata(palette, np.uint8)
     np.testing.assert_array_equal(cmap.values, [0, 1])
 
     with pytest.raises(AttributeError):
-        colormap.Colormap.from_xrda(palette/100, np.float32, {})
+        colormap.Colormap.from_array_with_metadata(palette/100, np.float32)
 
-    cmap = colormap.Colormap.from_xrda(
+    cmap = colormap.Colormap.from_array_with_metadata(
             palette,
             np.float32,
-            {"valid_range": [0, 100],
-             "scale_factor": 2})
+            valid_range=[0, 100],
+            scale_factor=2)
 
     np.testing.assert_array_equal(cmap.values, [0, 200])
 
@@ -705,7 +705,7 @@ def test_build_colormap_with_int_data_and_with_meanings():
     palette = xarray.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
                            dims=['value', 'band'])
     palette.attrs['palette_meanings'] = [2, 3, 4]
-    cmap = colormap.Colormap.from_xrda(palette, np.uint8, {})
+    cmap = colormap.Colormap.from_array_with_metadata(palette, np.uint8)
     np.testing.assert_array_equal(cmap.values, [2, 3, 4])
 
 

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -27,6 +27,7 @@ import unittest
 from trollimage import colormap
 import numpy as np
 from tempfile import NamedTemporaryFile
+import xarray
 
 import pytest
 
@@ -627,6 +628,85 @@ class TestFromFileCreation:
 
             with pytest.raises(ValueError):
                 colormap.Colormap.from_file(cmap_filename)
+
+    def test_cmap_from_string(self):
+        """Test creating a colormap from a string."""
+        s = "0,0,0,0\n1,1,1,1\n2,2,2,2"
+        cmap = colormap.Colormap.from_string(s, color_scale=1)
+        np.testing.assert_array_equal(cmap.values, [0, 1, 2])
+        np.testing.assert_array_equal(cmap.colors, [[0, 0, 0], [1, 1, 1,], [2, 2, 2]])
+
+    def test_cmap_from_np(self, tmp_path):
+        """Test creating a colormap from a numpy file."""
+        cmap_data = _generate_cmap_test_data(None, "RGB")
+        fnp = tmp_path / "test.npy"
+        np.save(fnp, cmap_data)
+        cmap = colormap.Colormap.from_np(fnp, color_scale=1)
+        np.testing.assert_allclose(cmap.values, [0, 0.33333333, 0.6666667, 1])
+        np.testing.assert_array_equal(cmap.colors, cmap_data)
+
+    def test_cmap_from_csv(self, tmp_path, color_scale=1):
+        """Test creating a colormap from a CSV file."""
+        cmap_data = _generate_cmap_test_data(None, "RGB")
+        fnp = tmp_path / "test.csv"
+        np.savetxt(fnp, cmap_data, delimiter=",")
+        cmap = colormap.Colormap.from_csv(fnp, color_scale=1)
+        np.testing.assert_allclose(cmap.values, [0, 0.33333333, 0.66666667, 1])
+        np.testing.assert_array_equal(cmap.colors, cmap_data)
+
+
+def test_cmap_from_ndarray():
+    """Test creating a colormap from a numpy array."""
+    cmap_data = _generate_cmap_test_data(None, "RGB")
+    cmap = colormap.Colormap.from_ndarray(cmap_data, color_scale=1)
+    np.testing.assert_allclose(cmap.values, [0, 0.33333333, 0.66666667, 1])
+    np.testing.assert_array_equal(cmap.colors, cmap_data)
+
+
+def test_cmap_from_name():
+    """Test creating a colormap from a string representing a name."""
+    cmap = colormap.Colormap.from_name("puor")
+    np.testing.assert_array_equal(cmap.values, colormap.puor.values)
+    np.testing.assert_array_equal(cmap.colors, colormap.puor.colors)
+
+
+def test_cmap_from_sequence_of_colors():
+    """Test creating a colormap from a sequence of colors."""
+    colors = [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11]]
+    cmap = colormap.Colormap.from_sequence_of_colors(colors, color_scale=2)
+    np.testing.assert_allclose(cmap.values, [0, 0.33333333, 0.66666667, 1])
+    np.testing.assert_array_equal(cmap.colors*2, colors)
+
+    vals = [0, 5, 10, 15]
+    cmap = colormap.Colormap.from_sequence_of_colors(colors, values=vals, color_scale=2)
+    np.testing.assert_allclose(cmap.values, [0, 5, 10, 15])
+
+
+def test_build_colormap_with_int_data_and_without_meanings():
+    """Test colormap building."""
+    palette = np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]])
+    cmap = colormap.Colormap.from_xrda(palette, np.uint8, {})
+    np.testing.assert_array_equal(cmap.values, [0, 1])
+
+    with pytest.raises(AttributeError):
+        colormap.Colormap.from_xrda(palette/100, np.float32, {})
+
+    cmap = colormap.Colormap.from_xrda(
+            palette,
+            np.float32,
+            {"valid_range": [0, 100],
+             "scale_factor": 2})
+
+    np.testing.assert_array_equal(cmap.values, [0, 200])
+
+
+def test_build_colormap_with_int_data_and_with_meanings():
+    """Test colormap building."""
+    palette = xarray.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
+                           dims=['value', 'band'])
+    palette.attrs['palette_meanings'] = [2, 3, 4]
+    cmap = colormap.Colormap.from_xrda(palette, np.uint8, {})
+    np.testing.assert_array_equal(cmap.values, [2, 3, 4])
 
 
 def _assert_monotonic_values(cmap, increasing=True):

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -695,9 +695,19 @@ def test_build_colormap_with_int_data_and_without_meanings():
             palette,
             np.float32,
             valid_range=[0, 100],
-            scale_factor=2)
+            scale_factor=2,
+            remove_last=True)
 
     np.testing.assert_array_equal(cmap.values, [0, 200])
+
+    cmap = colormap.Colormap.from_array_with_metadata(
+            palette,
+            np.float32,
+            valid_range=[0, 100],
+            scale_factor=2,
+            remove_last=False)
+
+    np.testing.assert_array_equal(cmap.values, [0, 100, 200])
 
 
 def test_build_colormap_with_int_data_and_with_meanings():

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -629,13 +629,6 @@ class TestFromFileCreation:
             with pytest.raises(ValueError):
                 colormap.Colormap.from_file(cmap_filename)
 
-    def test_cmap_from_string(self):
-        """Test creating a colormap from a string."""
-        s = "0,0,0,0\n1,1,1,1\n2,2,2,2"
-        cmap = colormap.Colormap.from_string(s, color_scale=1)
-        np.testing.assert_array_equal(cmap.values, [0, 1, 2])
-        np.testing.assert_array_equal(cmap.colors, [[0, 0, 0], [1, 1, 1], [2, 2, 2]])
-
     def test_cmap_from_np(self, tmp_path):
         """Test creating a colormap from a numpy file."""
         cmap_data = _generate_cmap_test_data(None, "RGB")
@@ -653,6 +646,14 @@ class TestFromFileCreation:
         cmap = colormap.Colormap.from_csv(fnp, color_scale=1)
         np.testing.assert_allclose(cmap.values, [0, 0.33333333, 0.66666667, 1])
         np.testing.assert_array_equal(cmap.colors, cmap_data)
+
+
+def test_cmap_from_string():
+    """Test creating a colormap from a string."""
+    s = "0,0,0,0\n1,1,1,1\n2,2,2,2"
+    cmap = colormap.Colormap.from_string(s, color_scale=1)
+    np.testing.assert_array_equal(cmap.values, [0, 1, 2])
+    np.testing.assert_array_equal(cmap.colors, [[0, 0, 0], [1, 1, 1], [2, 2, 2]])
 
 
 def test_cmap_from_ndarray():

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -634,7 +634,7 @@ class TestFromFileCreation:
         s = "0,0,0,0\n1,1,1,1\n2,2,2,2"
         cmap = colormap.Colormap.from_string(s, color_scale=1)
         np.testing.assert_array_equal(cmap.values, [0, 1, 2])
-        np.testing.assert_array_equal(cmap.colors, [[0, 0, 0], [1, 1, 1,], [2, 2, 2]])
+        np.testing.assert_array_equal(cmap.colors, [[0, 0, 0], [1, 1, 1], [2, 2, 2]])
 
     def test_cmap_from_np(self, tmp_path):
         """Test creating a colormap from a numpy file."""
@@ -703,7 +703,7 @@ def test_build_colormap_with_int_data_and_without_meanings():
 def test_build_colormap_with_int_data_and_with_meanings():
     """Test colormap building."""
     palette = xarray.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
-                           dims=['value', 'band'])
+                               dims=['value', 'band'])
     palette.attrs['palette_meanings'] = [2, 3, 4]
     cmap = colormap.Colormap.from_array_with_metadata(palette, np.uint8)
     np.testing.assert_array_equal(cmap.values, [2, 3, 4])


### PR DESCRIPTION
Refactoring colormap creation.  Move most colormap creation functionality from Satpy to here.  Deprecate passing a string containing a CSV to ``Colormap.from_file``, this should now use ``Colormap.from_string`` instead.

There remain some inconsistencies in the API, such as how values are guessed when not explicitly provided, but changing this would affect backward compatibility when coming from Satpy.

This PR also fixes numpy 1.24 compatibility.

 - [x] Closes https://github.com/pytroll/satpy/issues/2308 (partly)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
