### PR TITLE
Add more accurate RGB <-> HCL conversion for colorize interpolation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(name="trollimage",
       url="https://github.com/pytroll/trollimage",
       packages=['trollimage'],
       zip_safe=False,
-      install_requires=['numpy>=1.13', 'pillow'],
+      install_requires=['numpy>=1.20', 'pillow'],
       python_requires='>=3.6',
       extras_require={
           'geotiff': ['rasterio>=1.0'],

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -152,7 +152,40 @@ def _interpolate_rgb_colors(arr, colors, values):
 
 
 def rgb2hcl_numpy(rgba_arr: NDArray, gamma: float = 3.0, y_0: float = 100.0) -> NDArray:
-    """Convert numpy RGB[A] arrays to HCL (hue, chroma, lumnance) values."""
+    """Convert numpy RGB[A] arrays to HCL (hue, chroma, lumnance) values.
+
+    This algorithm is based on the work described in:
+
+    Madenda, Sarifuddin. (2005). A new perceptually uniform color space with associated
+    color similarity measure for content-based image and video retrieval. Multimedia
+    Information Retrieval Workshop, 28th Annual ACM SIGIR Conference.
+
+    Additionally, the code is a numpy-friendly port of the matlab code in:
+
+    Sarifuddin Madenda (2023). RGB to HCL and HCL to RGB color conversion
+    (https://www.mathworks.com/matlabcentral/fileexchange/100878-rgb-to-hcl-and-hcl-to-rgb-color-conversion),
+    MATLAB Central File Exchange. Retrieved January 20, 2023.
+
+    Lastly, the python code here is inspired by a similar implementation of the
+    same algorithm in the `colour-science` python package:
+
+    https://github.com/colour-science/colour
+
+    Args:
+        rgba_arr: Numpy array of RGB or RGBA colors. The array can be any
+            shape as long as the channel (band) dimension is the last (-1)
+            dimension. If an Alpha (A) channel is provided it is ignored.
+            Values should be between 0 and 1.
+        gamma: Correction factor (see related paper). In normal use this does
+            not need to be changed from the default of 3.0.
+        y_0: White reference luminance. In normal use this does not need to
+            be changed from the default of 100.0.
+
+    Returns: HCL numpy array where the last dimension represents Hue, Chroma,
+        and Luminance. Hue is in radians from -pi to pi. Chroma is from 0 to
+        1. Luminance is also from 0 and 1 (usually a maximum of ~0.5).
+
+    """
     rgb_arr = rgba_arr[..., :3]
     rgb_min = rgb_arr.min(axis=-1)
     rgb_max = rgb_arr.max(axis=-1)
@@ -183,7 +216,38 @@ def rgb2hcl_numpy(rgba_arr: NDArray, gamma: float = 3.0, y_0: float = 100.0) -> 
 
 
 def hcl2rgb_numpy(hcl_arr: NDArray, gamma: float = 3.0, y_0: float = 100.0) -> NDArray:
-    """Convert an HCL (hue, chroma, luminance) array to RGB."""
+    """Convert an HCL (hue, chroma, luminance) array to RGB.
+
+    This algorithm is based on the work described in:
+
+    Madenda, Sarifuddin. (2005). A new perceptually uniform color space with associated
+    color similarity measure for content-based image and video retrieval. Multimedia
+    Information Retrieval Workshop, 28th Annual ACM SIGIR Conference.
+
+    Additionally, the code is a numpy-friendly port of the matlab code in:
+
+    Sarifuddin Madenda (2023). RGB to HCL and HCL to RGB color conversion
+    (https://www.mathworks.com/matlabcentral/fileexchange/100878-rgb-to-hcl-and-hcl-to-rgb-color-conversion),
+    MATLAB Central File Exchange. Retrieved January 20, 2023.
+
+    Lastly, the python code here is inspired by a similar implementation of the
+    same algorithm in the `colour-science` python package:
+
+    https://github.com/colour-science/colour
+
+    Args:
+        hcl_arr: Numpy array of HCL values. The array can be any
+            shape as long as the channel (band) dimension is the last (-1)
+            dimension. Hue must be between -pi to pi. Chroma and Luminance
+            should be between 0 and 1.
+        gamma: Correction factor (see related paper). In normal use this does
+            not need to be changed from the default of 3.0.
+        y_0: White reference luminance. In normal use this does not need to
+            be changed from the default of 100.0.
+
+    Returns: RGB array where each Red, Green, and Blue channel is between 0 and 1.
+
+    """
     hue = hcl_arr[..., 0]  # in radians
     chroma = hcl_arr[..., 1]
     luminance = hcl_arr[..., 2]
@@ -208,8 +272,8 @@ def hcl2rgb_numpy(hcl_arr: NDArray, gamma: float = 3.0, y_0: float = 100.0) -> N
     # hue_n60_0 = ~hue_lt_n60 & ~hue_pos
     # r = np.where(hue_0_60 | hue_n60_0, rgb_max, np.where(hue_120_180, rgb_min, tamp))
     tan_3_2_H = np.tan(3 / 2 * hue)
-    tan_3_4_H_MP = np.tan(3 / 4 * (hue - np.pi))
-    tan_3_4_H = np.tan(3 / 4 * hue)
+    tan_3_4_H_MP = np.tan(3 / 4 * (hue - np.pi))  # np.tan(-pi/2) or np.tan(-pi/4)
+    tan_3_4_H = np.tan(3 / 4 * hue)  # np.tan(-pi/2) or np.tan(-pi/4)
     tan_3_2_H_PP = np.tan(3 / 2 * (hue + np.pi))
 
     r_p60 = np.radians(60)

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -463,7 +463,7 @@ class TestColormap:
         import dask.array as da
         data = da.from_array(np.array([[1.5, 2.5, 3.5, 4],
                                        [1.5, 2.5, 3.5, 4],
-                                       [1.5, 2.5, 3.5, 4]]), chunks=2)
+                                       [1.5, 2.5, 3.5, 4]]), chunks=-1)
 
         expected_channels = [np.array([[0.22178232, 0.61069262, 0.50011605, 0.],
                                        [0.22178232, 0.61069262, 0.50011605, 0.],
@@ -476,13 +476,15 @@ class TestColormap:
                                        [0.49104964, 1.20509947, 0.49989589, 0.]])]
 
         cm = _mono_inc_colormap()
-        channels = cm.colorize(data)
-        for i, expected_channel in enumerate(expected_channels):
-            current_channel = channels[i, :, :]
-            assert isinstance(current_channel, da.Array)
-            np.testing.assert_allclose(current_channel.compute(),
-                                       expected_channel,
-                                       atol=0.001)
+        import dask
+        with dask.config.set(scheduler='sync'):
+            channels = cm.colorize(data)
+            assert isinstance(channels, da.Array)
+            channels_np = channels.compute()
+        print(channels_np[:, 0])
+        np.testing.assert_allclose(channels_np[0], expected_channels[0], atol=0.001)
+        np.testing.assert_allclose(channels_np[1], expected_channels[1], atol=0.001)
+        np.testing.assert_allclose(channels_np[2], expected_channels[2], atol=0.001)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This PR adds a new implementation of RGB to HCL (and HCL to RGB) that is more accurate in more cases. It is based on the 2005 paper here:

https://www.researchgate.net/publication/228906385_A_new_perceptually_uniform_color_space_with_associated_color_similarity_measure_for_content-based_image_and_video_retrieval

And the matlab implementation here:

https://www.mathworks.com/matlabcentral/fileexchange/100878-rgb-to-hcl-and-hcl-to-rgb-color-conversion?s_tid=FX_rc1_behav

And the colour-science python package here:

https://github.com/colour-science/colour/blob/develop/colour/models/rgb/cylindrical.py#L361

As discussed in #106, the existing conversion does not handle certain cases where invalid division (divide by 0) or NaNs are involved. This is very obvious when you start using black or white in a colormap.

WIP TODO:

 - [ ] Refactor...refactor...refactor
 - [ ] Come up with a more clever/more efficient way to do NaN/grayscale handling in interpolation
 - [ ] Add keyword argument to rgb2hcl_numpy to control NaN handling
 - [ ] Test performance compared to old non-numpy code (ignoring accuracy)
 - [ ] Docstrings with references to publications
 - [ ] Optimize conversion methods a little further
 - [ ] Better name for `rgb2hcl_numpy` and `hcl2rgb_numpy`?

And other normal TODO:

 - [ ] Closes #106 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
