### PR TITLE
Don't scale colormap values if they're ints

### DIFF
--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -681,16 +681,18 @@ class Colormap(object):
             color_array,
             "VRGB" if color_array.shape[1] == 4 else "VRGBA",
             color_scale=color_scale)
+        if dtype == np.dtype("uint8"):
+            return colormap
+
         if valid_range is not None:
             if set_range:
                 colormap.set_range(
                     *(np.array(valid_range) * scale_factor
                       + add_offset))
-        else:
-            if dtype != np.dtype("uint8"):
-                raise AttributeError("Data need to have either a valid_range or be of type uint8" +
-                                     " in order to be displayable with an attached color-palette!")
-        return colormap
+            return colormap
+
+        raise AttributeError("Data need to have either a valid_range or be of type uint8" +
+                             " in order to be displayable with an attached color-palette!")
 
 
 def _is_actually_a_csv_string(string):

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -684,10 +684,22 @@ def test_cmap_from_sequence_of_colors():
 
 
 def test_build_colormap_with_int_data_and_without_meanings():
-    """Test colormap building."""
+    """Test colormap building from uint8 array with metadata."""
     palette = np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]])
     cmap = colormap.Colormap.from_array_with_metadata(palette, np.uint8)
     np.testing.assert_array_equal(cmap.values, [0, 1])
+
+    # test that values are respected even if valid_range is passed
+    # see https://github.com/pytroll/satpy/issues/2376
+    cmap = colormap.Colormap.from_array_with_metadata(
+            palette, np.uint8, valid_range=[0, 100])
+
+    np.testing.assert_array_equal(cmap.values, [0, 1])
+
+
+def test_build_colormap_with_float_data():
+    """Test colormap building for float data"""
+    palette = np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]])
 
     with pytest.raises(AttributeError):
         colormap.Colormap.from_array_with_metadata(palette/100, np.float32)


### PR DESCRIPTION
Do not scale colormap values if they're integers, even if a valid range is set.

 - [x] Closes https://github.com/pytroll/satpy/issues/2376 
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)

