### PR TITLE
Temporarily disable Python 3.12 wheel building

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         env:
-          CIBW_SKIP: "cp36-* cp37-* cp38-* pp* *-i686"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* cp312-* pp* *-i686"
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Numpy compatibility with 3.12 is a little weird right now. We can't build 3.12 wheels yet.


 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
