### PR TITLE
Keep the original dtype of the data when stretching

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1477,12 +1477,23 @@ class TestXRImage:
         expected_blue = (arr[:, :, 2] - 2.) / (74. - 2.)
         np.testing.assert_allclose(blue, expected_blue.astype(np.float32), rtol=1e-6)
 
+    def test_crude_stretch_with_limits(self):
         arr = np.arange(75).reshape(5, 5, 3).astype(float)
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
         img.crude_stretch(0, 74)
+        assert img.data.dtype == float
         np.testing.assert_allclose(img.data.values, arr / 74.)
+
+    def test_crude_stretch_integer_data(self):
+        arr = np.arange(75, dtype=int).reshape(5, 5, 3)
+        data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
+                            coords={'bands': ['R', 'G', 'B']})
+        img = xrimage.XRImage(data)
+        img.crude_stretch(0, 74)
+        assert img.data.dtype == np.float32
+        np.testing.assert_allclose(img.data.values, arr.astype(np.float32) / 74., rtol=1e-6)
 
     def test_invert(self):
         """Check inversion of the image."""

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2329,10 +2329,10 @@ class TestXRImageSaveScaleOffset:
     def setup_method(self) -> None:
         """Set up the test case."""
         from trollimage import xrimage
-        data = xr.DataArray(np.arange(25).reshape(5, 5, 1), dims=[
+        data = xr.DataArray(np.arange(25, dtype=np.float32).reshape(5, 5, 1), dims=[
             'y', 'x', 'bands'], coords={'bands': ['L']})
         self.img = xrimage.XRImage(data)
-        rgb_data = xr.DataArray(np.arange(3 * 25).reshape(5, 5, 3), dims=[
+        rgb_data = xr.DataArray(np.arange(3 * 25, dtype=np.float32).reshape(5, 5, 3), dims=[
             'y', 'x', 'bands'], coords={'bands': ['R', 'G', 'B']})
         self.rgb_img = xrimage.XRImage(rgb_data)
 

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1456,7 +1456,7 @@ class TestXRImage:
 
     def test_crude_stretch(self):
         """Check crude stretching."""
-        arr = np.arange(75).reshape(5, 5, 3)
+        arr = np.arange(75, dtype=np.float32).reshape(5, 5, 3)
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
@@ -1467,11 +1467,15 @@ class TestXRImage:
         enhs = img.data.attrs['enhancement_history'][0]
         scale_expected = np.array([0.01388889, 0.01388889, 0.01388889])
         offset_expected = np.array([0., -0.01388889, -0.02777778])
+        assert img.data.dtype == np.float32
         np.testing.assert_allclose(enhs['scale'].values, scale_expected)
         np.testing.assert_allclose(enhs['offset'].values, offset_expected)
-        np.testing.assert_allclose(red, arr[:, :, 0] / 72.)
-        np.testing.assert_allclose(green, (arr[:, :, 1] - 1.) / (73. - 1.))
-        np.testing.assert_allclose(blue, (arr[:, :, 2] - 2.) / (74. - 2.))
+        expected_red = arr[:, :, 0] / 72.
+        np.testing.assert_allclose(red, expected_red.astype(np.float32), rtol=1e-6)
+        expected_green = (arr[:, :, 1] - 1.) / (73. - 1.)
+        np.testing.assert_allclose(green, expected_green.astype(np.float32), rtol=1e-6)
+        expected_blue = (arr[:, :, 2] - 2.) / (74. - 2.)
+        np.testing.assert_allclose(blue, expected_blue.astype(np.float32), rtol=1e-6)
 
         arr = np.arange(75).reshape(5, 5, 3).astype(float)
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1081,13 +1081,13 @@ class XRImage:
         delta = (max_stretch - min_stretch)
         if isinstance(delta, xr.DataArray):
             # fillna if delta is NaN
-            scale_factor = (1.0 / delta).fillna(0)
+            scale_factor = (1.0 / delta).fillna(0).astype(self.data.dtype)
         else:
-            scale_factor = 1.0 / delta
+            scale_factor = self.data.dtype.type(1.0 / delta)
         attrs = self.data.attrs
         offset = -min_stretch * scale_factor
-        self.data *= scale_factor.astype(self.data.dtype)
-        self.data += offset.astype(self.data.dtype)
+        self.data *= scale_factor
+        self.data += offset
         self.data.attrs = attrs
         self.data.attrs.setdefault('enhancement_history', []).append({'scale': scale_factor,
                                                                       'offset': offset})

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1078,8 +1078,12 @@ class XRImage:
         if isinstance(max_stretch, (list, tuple)):
             max_stretch = self.xrify_tuples(max_stretch)
 
-        min_stretch = min_stretch.astype(self.data.dtype)
-        max_stretch = max_stretch.astype(self.data.dtype)
+        try:
+            min_stretch = min_stretch.astype(self.data.dtype)
+            max_stretch = max_stretch.astype(self.data.dtype)
+        except AttributeError:
+            min_stretch = self.data.dtype.type(min_stretch)
+            max_stretch = self.data.dtype.type(max_stretch)
 
         delta = (max_stretch - min_stretch)
         if isinstance(delta, xr.DataArray):

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1086,8 +1086,8 @@ class XRImage:
             scale_factor = 1.0 / delta
         attrs = self.data.attrs
         offset = -min_stretch * scale_factor
-        self.data *= scale_factor
-        self.data += offset
+        self.data *= scale_factor.astype(self.data.dtype)
+        self.data += offset.astype(self.data.dtype)
         self.data.attrs = attrs
         self.data.attrs.setdefault('enhancement_history', []).append({'scale': scale_factor,
                                                                       'offset': offset})

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1078,6 +1078,9 @@ class XRImage:
         if isinstance(max_stretch, (list, tuple)):
             max_stretch = self.xrify_tuples(max_stretch)
 
+        min_stretch = min_stretch.astype(self.data.dtype)
+        max_stretch = max_stretch.astype(self.data.dtype)
+
         delta = (max_stretch - min_stretch)
         if isinstance(delta, xr.DataArray):
             # fillna if delta is NaN


### PR DESCRIPTION
The stretching forces the dtype to `float64`. This PR makes sure the original dtype is preserved.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
