### PR TITLE
Fix stretching integer data

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1631,6 +1631,18 @@ class TestXRImage:
 
         np.testing.assert_allclose(img.data.values, res, atol=1.e-6)
 
+    def test_linear_stretch_uint8(self):
+        """Test linear stretch with uint8 data."""
+        arr = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
+        arr[4, 4, :] = 255
+        data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
+                            coords={'bands': ['R', 'G', 'B']})
+        img = xrimage.XRImage(data)
+        img.stretch_linear()
+
+        assert img.data.values.min() == pytest.approx(0.0)
+        assert img.data.values.max() == pytest.approx(1.0960743801652901)
+
     @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))
     def test_histogram_stretch(self, dtype):
         """Test histogram stretching."""

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1631,16 +1631,17 @@ class TestXRImage:
 
         np.testing.assert_allclose(img.data.values, res, atol=1.e-6)
 
-    def test_linear_stretch_uint8(self):
-        """Test linear stretch with uint8 data."""
-        arr = np.arange(75, dtype=np.uint8).reshape(5, 5, 3)
+    @pytest.mark.parametrize("dtype", (np.uint8, np.uint16, int))
+    def test_linear_stretch_integer(self, dtype):
+        """Test linear stretch with integer data."""
+        arr = np.arange(75, dtype=dtype).reshape(5, 5, 3)
         arr[4, 4, :] = 255
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
         img.stretch_linear()
 
-        assert img.data.values.min() == pytest.approx(0.0)
+        assert img.data.values.min() == pytest.approx(-0.0015614156835530892)
         assert img.data.values.max() == pytest.approx(1.0960743801652901)
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1631,18 +1631,24 @@ class TestXRImage:
 
         np.testing.assert_allclose(img.data.values, res, atol=1.e-6)
 
-    @pytest.mark.parametrize("dtype", (np.uint8, np.uint16, int))
-    def test_linear_stretch_integer(self, dtype):
-        """Test linear stretch with integer data."""
-        arr = np.arange(75, dtype=dtype).reshape(5, 5, 3)
-        arr[4, 4, :] = 255
+    @pytest.mark.parametrize(("dtype", "max_val", "exp_min", "exp_max"),
+                             ((np.uint8, 255, -0.005358012691140175, 1.0053772069513798),
+                              (np.int8, 127, -0.004926108196377754, 1.0058689523488282),
+                              (np.uint16, 65535, -0.005050825305515899, 1.005050893505104),
+                              (np.int16, 32767, -0.005052744992717635, 1.0050527782880818),
+                              (np.uint32, 4294967295, -0.005050505077517274, 1.0050505395923495),
+                              (np.int32, 2147483647, -0.00505050499355784, 1.0050505395923495),
+                              (int, 2147483647, -0.00505050499355784, 1.0050505395923495),
+                              ))
+    def test_linear_stretch_integers(self, dtype, max_val, exp_min, exp_max):
+        """Test linear stretch with low-bit unsigned integer data."""
+        arr = np.linspace(0, max_val, num=75, dtype=dtype).reshape(5, 5, 3)
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
         img.stretch_linear()
-
-        assert img.data.values.min() == pytest.approx(-0.0015614156835530892)
-        assert img.data.values.max() == pytest.approx(1.0960743801652901)
+        assert img.data.values.min() == pytest.approx(exp_min)
+        assert img.data.values.max() == pytest.approx(exp_max)
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))
     def test_histogram_stretch(self, dtype):

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1097,7 +1097,7 @@ class XRImage:
             val = self.xrify_tuples(val)
 
         dtype = self.data.dtype
-        if isinstance(dtype, (np.uint8, np.int8, np.uint16, np.int16)):
+        if dtype in (np.uint8, np.int8, np.uint16, np.int16):
             dtype = np.dtype(np.float32)
         elif np.issubdtype(dtype, np.integer) or isinstance(dtype, int):
             dtype = np.dtype(np.float64)

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1097,8 +1097,10 @@ class XRImage:
             val = self.xrify_tuples(val)
 
         dtype = self.data.dtype
-        if np.issubdtype(dtype, np.integer):
+        if isinstance(dtype, (np.uint8, np.int8, np.uint16, np.int16)):
             dtype = np.dtype(np.float32)
+        elif np.issubdtype(dtype, np.integer) or isinstance(dtype, int):
+            dtype = np.dtype(np.float64)
         try:
             val = val.astype(dtype)
         except AttributeError:

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1082,6 +1082,7 @@ class XRImage:
 
         attrs = self.data.attrs
         offset = -min_stretch * scale_factor
+
         self.data = np.multiply(self.data, scale_factor, dtype=scale_factor.dtype) + offset
         self.data.attrs = attrs
         self.data.attrs.setdefault('enhancement_history', []).append({'scale': scale_factor,
@@ -1095,8 +1096,11 @@ class XRImage:
         if isinstance(val, (list, tuple)):
             val = self.xrify_tuples(val)
 
+        dtype = self.data.dtype
+        if np.issubdtype(dtype, np.integer):
+            dtype = np.dtype(np.float32)
         try:
-            val = val.astype(self.data.dtype)
+            val = val.astype(dtype)
         except AttributeError:
             val = self.data.dtype.type(val)
 


### PR DESCRIPTION
This PR fixes stretching of linear integer data. The bug was introduced in #150 due to lack of testing.

 - [x] Closes #152  (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
