### PR TITLE
Build wheels with numpy 2

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -64,6 +64,9 @@ jobs:
           CIBW_SKIP: "cp36-* cp37-* cp38-* pp* *-manylinux_i686 *-musllinux_i686 *-musllinux_aarch64 *-win32"
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
+          # below only for building against unstable numpy
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_BEFORE_BUILD: "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython setuptools versioneer"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Until numpy 2 is officially out these changes are needed to build a wheel compatible with numpy 1 and numpy 2.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
