### PR TITLE
Implement set_alpha_channel in Colorbar

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,6 @@ jobs:
           git+https://github.com/dask/distributed \
           git+https://github.com/rasterio/rasterio \
           git+https://github.com/pydata/bottleneck \
-          git+https://github.com/zarr-developers/zarr \
           git+https://github.com/pydata/xarray;
           python -m pip install -e . --no-deps --no-build-isolation;
 

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -382,7 +382,6 @@ class Colormap(object):
                 If False, return a new Colormap instance.
 
         """
-
         if inplace:
             cmap = self
         else:

--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -365,6 +365,42 @@ class Colormap(object):
         cmap.values = values
         return cmap
 
+    def set_alpha_range(self, min_alpha, max_alpha, inplace=True):
+        """Set the colormap alpha channel between two values in linear steps.
+
+        If the input colormap does not have an alpha channel,
+        it will be added to it. If an alpha channel is already existing,
+        the values will be overwritten.
+
+        The min and max values shall be between 0 (completely transparent)
+        and 1 (completely opaque).
+
+        Args:
+            min_alpha (float): Start value of the alpha channel [0-1]
+            max_alpha (float): End value of the alpha channel [0-1]
+            inplace (bool): If True (default), modify the values inplace.
+                If False, return a new Colormap instance.
+
+        """
+
+        if inplace:
+            cmap = self
+        else:
+            cmap = Colormap(
+                values=self.values.copy(),
+                colors=self.colors.copy())
+
+        alpha = np.linspace(min_alpha,
+                            max_alpha,
+                            self.colors.shape[0])
+
+        if cmap.colors.shape[1] == 4:
+            cmap.colors[:, 3] = alpha
+        else:
+            cmap.colors = np.column_stack((cmap.colors, alpha))
+
+        return cmap
+
     def to_rio(self):
         """Convert the colormap to a rasterio colormap.
 
@@ -687,7 +723,7 @@ class Colormap(object):
             # remove the last value because monkeys don't like water sprays
             # on a more serious note, I don't know why we are removing the last
             # value here, but this behaviour was copied from ancient satpy code
-            values = np.arange(squeezed_palette.shape[0]-remove_last)
+            values = np.arange(squeezed_palette.shape[0] - remove_last)
             if remove_last:
                 squeezed_palette = squeezed_palette[:-remove_last, :]
 


### PR DESCRIPTION
This PR adds the possibility to define an alpha channel range to be applied to a colormap.

 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
