### PR TITLE
Fix various numpy 2 and new xarray casting issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,6 @@ jobs:
           git+https://github.com/dask/distributed \
           git+https://github.com/rasterio/rasterio \
           git+https://github.com/pydata/bottleneck \
-          git+https://github.com/zarr-developers/zarr \
           git+https://github.com/pydata/xarray;
           python -m pip install -e . --no-deps --no-build-isolation;
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ xfail_strict = true
 filterwarnings = [
     "error",
     "ignore::rasterio.errors.NotGeoreferencedWarning",
+    # remove when fixed by xarray
+    "ignore:__array_wrap__ must accept context and return_scalar arguments:DeprecationWarning:numpy",
     # dateutil needs a new release
     # https://github.com/dateutil/dateutil/issues/1314
     'ignore:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning:dateutil',


### PR DESCRIPTION
This should fix various casting issues that didn't show up until xarray fixed their numpy 2 compatibility. This should likely be merged and released as a bug fix as quickly as possible. I will try to comment inline on all the changes for why they were needed.

CC @ameraner whose PR we first saw failures in

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
