### PR TITLE
Make palettize work on numpy 2.0.

### DIFF
--- a/trollimage/colormap.py
+++ b/trollimage/colormap.py
@@ -179,11 +179,11 @@ def _palettize(arr, values):
 def _digitize_array(arr, values):
     if values[0] <= values[-1]:
         # monotonic increasing values
-        outside_range_bin = max(np.nanmax(arr), values.max()) + 1
+        outside_range_bin = max(np.nanmax(arr), values.max()) + np.int64(1)
         right = False
     else:
         # monotonic decreasing values
-        outside_range_bin = min(np.nanmin(arr), values.min()) - 1
+        outside_range_bin = min(np.nanmin(arr), values.min()) - np.int64(1)
         right = True
     bins = np.concatenate((values, [outside_range_bin]))
 

--- a/trollimage/tests/test_colormap.py
+++ b/trollimage/tests/test_colormap.py
@@ -414,6 +414,15 @@ class TestColormap:
                                                         [0, 1, 2, 3]])
         assert channels.dtype == int
 
+    def test_palettize_edge_of_dtype_range(self):
+        """Test palettize when bins span the entire dtype range."""
+        from trollimage.colormap import palettize
+
+        arr = np.linspace(0, 255, 100, dtype=np.uint8).reshape(10, 10)
+        colors = np.linspace(0, 255, 768).reshape(256, 3)
+        values = np.arange(0, 256, dtype=np.uint8)
+        palettize(arr, colors, values)
+
     @pytest.mark.parametrize(
         ("input_cmap_func", "expected_result"),
         [


### PR DESCRIPTION
Make palettize work on numpy 2.0.

 - [x] Closes #175 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
