### PR TITLE
Allow overriding scale and offset values

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2676,6 +2676,15 @@ class TestXRImageSaveScaleOffset:
             expected_tags,
             scale_offset_tags=("gradient", "axis_intercept"))
 
+    @pytest.mark.skipif(sys.platform.startswith('win'), reason="'NamedTemporaryFile' not supported on Windows")
+    def test_save_scale_offset_custom_values(self):
+        """Test saving GeoTIFF overriding the scale/offset values."""
+        expected_tags = {"gradient": 1, "axis_intercept": 0}
+        self.img.stretch()
+        self._save_and_check_tags(
+            expected_tags,
+            scale_offset_tags={"gradient": 1, "axis_intercept": 0})
+
 
 def _get_tags_after_writing_to_geotiff(data):
     import rasterio as rio

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -305,7 +305,7 @@ class XRImage:
                 provided. Common values include `nearest` (default),
                 `bilinear`, `average`, and many others. See the rasterio
                 documentation for more information.
-            scale_offset_tags (Tuple[str, str] or None):
+            scale_offset_tags (Tuple[str, str] or Dict[str, number] or None):
                 If set to a ``(str, str)`` tuple, scale and offset will be
                 stored in GDALMetaData tags.  Those can then be used to
                 retrieve the original data values from pixel values.
@@ -314,7 +314,9 @@ class XRImage:
                 represented by a simple scale and offset. Scale and offset
                 are also saved as (NaN, NaN) for multi-band images (ex. RGB)
                 as storing multiple values in a single GDALMetaData tag is not
-                currently supported.
+                currently supported.  If set to a dictionary, automatically
+                determined scale/offset values are overruled by the values
+                provided in the keys.
             colormap_tag (str or None):
                 If set and the image was colorized or palettized, a tag will
                 be added with this name with the value of a comma-separated
@@ -471,7 +473,11 @@ class XRImage:
 
     def _add_scale_offset_to_tags(self, scale_offset_tags, data_arr, tags):
         scale_label, offset_label = scale_offset_tags
-        scale, offset = self.get_scaling_from_history(data_arr.attrs.get('enhancement_history', []))
+        try:
+            scale = scale_offset_tags[scale_label]
+            offset = scale_offset_tags[offset_label]
+        except TypeError:
+            scale, offset = self.get_scaling_from_history(data_arr.attrs.get('enhancement_history', []))
         tags[scale_label], tags[offset_label] = invert_scale_offset(scale, offset)
 
     def get_scaling_from_history(self, history=None):


### PR DESCRIPTION
Add an option to override the automatically calculated scale and offset tags.

 - [x] Partially closes https://github.com/pytroll/satpy/issues/2869
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
