### PR TITLE
Adapt fill value after palettizing.

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2600,6 +2600,16 @@ class TestXRImagePalettize:
                 np.testing.assert_allclose(new_brbg.values, loaded_brbg.values)
                 np.testing.assert_allclose(new_brbg.colors, loaded_brbg.colors)
 
+    def test_palettize_fill_value(self):
+        """Test that fill values are adapted."""
+
+        arr = np.arange(25, dtype="float32").reshape(5, 5)/25
+        arr[2, 2] = np.nan
+        data = xr.DataArray(arr.copy(), dims=['y', 'x'], attrs={"_FillValue": np.nan})
+        img = xrimage.XRImage(data)
+        img.palettize(brbg)
+        assert img.data[0, 2, 2] == img.data.attrs["_FillValue"]
+
 
 class TestXRImageSaveScaleOffset:
     """Test case for saving an image with scale and offset tags."""

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2615,7 +2615,7 @@ class TestXRImagePalettize:
         data = xr.DataArray(arr.copy(), dims=['y', 'x'], attrs={"_FillValue": 10})
         img = xrimage.XRImage(data)
         with pytest.warns(UserWarning,
-                          match="Palettizing uint8 data with fill value set to 10, "
+                          match="Palettizing uint8 data with the _FillValue attribute set to 10, "
                                 "but palettize is not generally fill value aware"):
             img.palettize(brbg)
 

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2609,6 +2609,15 @@ class TestXRImagePalettize:
         img.palettize(brbg)
         assert img.data[0, 2, 2] == img.data.attrs["_FillValue"]
 
+    def test_palettize_bad_fill_value(self):
+        """Test that palettize warns with a strange fill value."""
+        arr = np.arange(25, dtype="uint8").reshape(5, 5)
+        data = xr.DataArray(arr.copy(), dims=['y', 'x'], attrs={"_FillValue": 10})
+        img = xrimage.XRImage(data)
+        with pytest.warns(UserWarning,
+                          match="Palettizing uint8 data with fill value set to 10, "
+                                "but palettize is not generally fill value aware"):
+            img.palettize(brbg)
 
 class TestXRImageSaveScaleOffset:
     """Test case for saving an image with scale and offset tags."""

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2619,6 +2619,7 @@ class TestXRImagePalettize:
                                 "but palettize is not generally fill value aware"):
             img.palettize(brbg)
 
+
 class TestXRImageSaveScaleOffset:
     """Test case for saving an image with scale and offset tags."""
 

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -2602,7 +2602,6 @@ class TestXRImagePalettize:
 
     def test_palettize_fill_value(self):
         """Test that fill values are adapted."""
-
         arr = np.arange(25, dtype="float32").reshape(5, 5)/25
         arr[2, 2] = np.nan
         data = xr.DataArray(arr.copy(), dims=['y', 'x'], attrs={"_FillValue": np.nan})

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1523,7 +1523,7 @@ class XRImage:
                 "will be correctly palettized only for float with NaN or for "
                 "ints with fill value set to dtype max.",
                 UserWarning,
-                stacklevel=2)
+                stacklevel=3)
         # else: non-numeric data, probably doesn't work at all and will fail
         # elsewhere anyway
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1517,7 +1517,7 @@ class XRImage:
         # not OK: float or int with different fill value
         elif "_FillValue" in self.data.attrs:
             warnings.warn(
-                f"Palettizing {old_dtype.name:s} data with fill value set to "
+                f"Palettizing {old_dtype.name:s} data with the _FillValue attribute set to "
                 f"{self.data.attrs['_FillValue']!s}, "
                  "but palettize is not generally fill value aware (masked data "
                  "will be correctly palettized only for float with NaN or for "

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -33,6 +33,7 @@ chunks can be saved in parallel.
 """
 
 import logging
+import math
 import numbers
 import os
 import warnings
@@ -1484,9 +1485,10 @@ class XRImage:
             mode = "PA"
             new_data = da.concatenate([new_data, self.data.sel(bands=['A'])], axis=0)
 
+        old_dtype = self.data.dtype
         self.data.data = new_data
         self.data.coords['bands'] = list(mode)
-        self.data.attrs["_FillValue"] = colormap.values.shape[0]-1
+        self._set_new_fill_value_after_palettize(colormap, old_dtype)
         # See docstring notes above for how scale/offset should be used
         scale_factor, offset = self._get_colormap_scale_offset(colormap)
         self.data.attrs.setdefault('enhancement_history', []).append({
@@ -1502,6 +1504,27 @@ class XRImage:
         scale_factor = 1.0 / (cmap_max - cmap_min)
         offset = -cmap_min * scale_factor
         return scale_factor, offset
+
+    def _set_new_fill_value_after_palettize(self, colormap, old_dtype):
+        """Set new fill value after palettizing."""
+        # OK: float without fill value or fill value nan
+        # OK: int without fill value or fill value to max value
+        if ((np.issubdtype(old_dtype, np.inexact) and
+             math.isnan(self.data.attrs.get("_FillValue", np.nan))) or
+            (np.issubdtype(old_dtype, np.integer) and
+             self.data.attrs.get("_FillValue", np.iinfo(old_dtype).max) == np.iinfo(old_dtype.max))):
+            self.data.attrs["_FillValue"] = colormap.values.shape[0]-1
+        # not OK: float or int with different fill value
+        elif "_FillValue" in self.data.attrs:
+            warnings.warn(
+                f"Palettizing {old_dtype.name:s} data with fill value set to, "
+                f"{self.data.attrs['_FillValue']!s}, "
+                 "but palettize is not generally fill value aware (masked data "
+                 "will be correctly palettized only for float with NaN or for "
+                 "ints with fill value set to dtype max.",
+                  UserWarning)
+        # else: non-numeric data, probably doesn't work at all and will fail
+        # elsewhere anyway
 
     def blend(self, src):
         r"""Alpha blend *src* on top of the current image.

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1512,12 +1512,12 @@ class XRImage:
         if ((np.issubdtype(old_dtype, np.inexact) and
              math.isnan(self.data.attrs.get("_FillValue", np.nan))) or
             (np.issubdtype(old_dtype, np.integer) and
-             self.data.attrs.get("_FillValue", np.iinfo(old_dtype).max) == np.iinfo(old_dtype.max))):
+             self.data.attrs.get("_FillValue", np.iinfo(old_dtype).max) == np.iinfo(old_dtype).max)):
             self.data.attrs["_FillValue"] = colormap.values.shape[0]-1
         # not OK: float or int with different fill value
         elif "_FillValue" in self.data.attrs:
             warnings.warn(
-                f"Palettizing {old_dtype.name:s} data with fill value set to, "
+                f"Palettizing {old_dtype.name:s} data with fill value set to "
                 f"{self.data.attrs['_FillValue']!s}, "
                  "but palettize is not generally fill value aware (masked data "
                  "will be correctly palettized only for float with NaN or for "

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1519,10 +1519,11 @@ class XRImage:
             warnings.warn(
                 f"Palettizing {old_dtype.name:s} data with the _FillValue attribute set to "
                 f"{self.data.attrs['_FillValue']!s}, "
-                 "but palettize is not generally fill value aware (masked data "
-                 "will be correctly palettized only for float with NaN or for "
-                 "ints with fill value set to dtype max.",
-                  UserWarning)
+                "but palettize is not generally fill value aware (masked data "
+                "will be correctly palettized only for float with NaN or for "
+                "ints with fill value set to dtype max.",
+                UserWarning,
+                stacklevel=2)
         # else: non-numeric data, probably doesn't work at all and will fail
         # elsewhere anyway
 

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1428,6 +1428,9 @@ class XRImage:
         To (directly) get an image in mode "RGB" or "RGBA", use
         :meth:`~XRImage.colorize`.
 
+        Invalid data (NaN) are sorted into the final bin and the ``_FillValue``
+        attributed for the resulting image is set to the corresponding value.
+
         Args:
             colormap (:class:`~trollimage.colormap.Colormap`):
                 Colormap to be applied to the image.

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -33,7 +33,6 @@ chunks can be saved in parallel.
 """
 
 import logging
-import math
 import numbers
 import os
 import warnings
@@ -1510,7 +1509,7 @@ class XRImage:
         # OK: float without fill value or fill value nan
         # OK: int without fill value or fill value to max value
         if ((np.issubdtype(old_dtype, np.inexact) and
-             math.isnan(self.data.attrs.get("_FillValue", np.nan))) or
+             np.isnan(self.data.attrs.get("_FillValue", np.nan))) or
             (np.issubdtype(old_dtype, np.integer) and
              self.data.attrs.get("_FillValue", np.iinfo(old_dtype).max) == np.iinfo(old_dtype).max)):
             self.data.attrs["_FillValue"] = colormap.values.shape[0]-1

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1483,6 +1483,7 @@ class XRImage:
 
         self.data.data = new_data
         self.data.coords['bands'] = list(mode)
+        self.data.attrs["_FillValue"] = colormap.values.shape[0]-1
         # See docstring notes above for how scale/offset should be used
         scale_factor, offset = self._get_colormap_scale_offset(colormap)
         self.data.attrs.setdefault('enhancement_history', []).append({


### PR DESCRIPTION
Adapt fill value after palettizing.

When floating point data are palettized, the resulting image has integer dtype (typically uint8) where the values are indices to a colormap.  The fill value will need to be updated, because a floating point fill value is not a valid index.  Invalid data (NaN) are always sorted into the final bin.  Therefore, the new fill value should correspond to the index for the final value in the colour table.

 - [x] Closes #178 (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [x] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
