### PR TITLE
Respect fill value when saving palette images while keeping the palette.

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (c) 2009-2021 trollimage developers
+# Copyright (c) 2009-2024 trollimage developers
 #
 # This file is part of trollimage.
 #
@@ -1383,6 +1381,25 @@ class TestXRImage:
             with pytest.raises(ValueError):
                 img.save(tmp.name, keep_palette=True, cmap=t_cmap,
                          dtype='uint16')
+
+    def test_save_geotiff_with_cmap_and_fill_value(self, tmp_path):
+        """Test saving GeoTIFF with colormap and fill value."""
+        import rasterio
+        test_file = tmp_path / "test.tif"
+        fv = np.uint8(42)
+        arr = np.ones((1, 5, 5), dtype="uint8")
+        arr[0, 2, 2] = 255
+        data = xr.DataArray(
+                arr,
+                dims=["bands", 'y', 'x'],
+                attrs={"_FillValue": 255},
+                coords={"bands": ["P"]})
+        img = xrimage.XRImage(data)
+        img.save(test_file, keep_palette=True, cmap=brbg,
+                 fill_value=fv)
+        with rasterio.open(test_file) as f:
+            cont = f.read()
+            assert cont[0, 2, 2] == fv
 
     @pytest.mark.skipif(sys.platform.startswith('win'),
                         reason="'NamedTemporaryFile' not supported on Windows")

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -2,11 +2,6 @@
 #
 # This file is part of trollimage.
 #
-# trollimage is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
When saving palette images with `keep_palette=True`, respect the fill value like for other images.

 - [x] Closes #180
 - [x] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
