### PR TITLE
Fix dtype promotion in channel inversion

### DIFF
--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1605,6 +1605,7 @@ class TestXRImage:
         img.invert(True)
         enhs = img.data.attrs['enhancement_history'][0]
         assert enhs == {'scale': -1, 'offset': 1}
+        assert img.data.dtype == dtype
         assert np.allclose(img.data.values, 1 - arr)
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))

--- a/trollimage/tests/test_image.py
+++ b/trollimage/tests/test_image.py
@@ -1595,8 +1595,8 @@ class TestXRImage:
         np.testing.assert_allclose(img.data.values, arr.astype(np.float32) / max_stretch, rtol=1e-6)
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))
-    def test_invert(self, dtype):
-        """Check inversion of the image."""
+    def test_invert_single_parameter(self, dtype):
+        """Check inversion of the image for single inversion parameter."""
         arr = np.arange(75, dtype=dtype).reshape(5, 5, 3) / 75.
         data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
@@ -1605,10 +1605,13 @@ class TestXRImage:
         img.invert(True)
         enhs = img.data.attrs['enhancement_history'][0]
         assert enhs == {'scale': -1, 'offset': 1}
-        assert img.data.dtype == dtype
         assert np.allclose(img.data.values, 1 - arr)
 
-        data = xr.DataArray(arr.copy(), dims=['y', 'x', 'bands'],
+    @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))
+    def test_invert_parameter_for_each_channel(self, dtype):
+        """Check inversion of the image for single inversion parameter."""
+        arr = np.arange(75, dtype=dtype).reshape(5, 5, 3) / 75.
+        data = xr.DataArray(arr, dims=['y', 'x', 'bands'],
                             coords={'bands': ['R', 'G', 'B']})
         img = xrimage.XRImage(data)
 
@@ -1618,6 +1621,7 @@ class TestXRImage:
         scale = xr.DataArray(np.array([-1, 1, -1]), dims=['bands'],
                              coords={'bands': ['R', 'G', 'B']})
         np.testing.assert_allclose(img.data.values, (data * scale + offset).values)
+        assert img.data.dtype == dtype
 
     @pytest.mark.parametrize("dtype", (np.float32, np.float64, float))
     def test_linear_stretch(self, dtype):

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1301,7 +1301,7 @@ class XRImage:
         logger.debug("Applying invert with parameters %s", str(invert))
         if isinstance(invert, (tuple, list)):
             invert = self.xrify_tuples(invert)
-            offset = invert.astype(np.int8)
+            offset = invert.astype(self.data.dtype)
             scale = (-1) ** offset
         elif invert:
             offset = 1

--- a/trollimage/xrimage.py
+++ b/trollimage/xrimage.py
@@ -1132,7 +1132,6 @@ class XRImage:
         if val is None:
             non_band_dims = tuple(x for x in self.data.dims if x != 'bands')
             val = getattr(self.data, kind)(dim=non_band_dims)
-
         if isinstance(val, (list, tuple)):
             val = self.xrify_tuples(val)
 
@@ -1302,7 +1301,7 @@ class XRImage:
         logger.debug("Applying invert with parameters %s", str(invert))
         if isinstance(invert, (tuple, list)):
             invert = self.xrify_tuples(invert)
-            offset = invert.astype(int)
+            offset = invert.astype(np.int8)
             scale = (-1) ** offset
         elif invert:
             offset = 1


### PR DESCRIPTION
The `XRImage.invert()` promotes data to `float64` when inversion parameters are given for each channel separately. The `dtype` was tested only for single inversion parameter case, not when they were given for each channel.

This PR splits the test case into two and adds the `dtype` check also for the per-channel case. And fixes the issue.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
