### PR TITLE
Optimize linear stretch to work with newer dask

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         experimental: [false]
         include:
           - python-version: "3.12"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12", "3.13"]
         experimental: [false]
         include:
-          - python-version: "3.12"
+          - python-version: "3.13"
             os: "ubuntu-latest"
             experimental: true
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
-          CIBW_SKIP: "cp36-* cp37-* cp38-* pp* *-manylinux_i686 *-musllinux_i686 *-musllinux_aarch64 *-win32"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* pp* *-manylinux_i686 *-musllinux_i686 *-musllinux_aarch64 *-win32"
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             cibw_archs: "AMD64 ARM64"
             artifact_name: "win"
           - os: macos-13

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(name="trollimage",
       packages=find_packages(),
       zip_safe=False,
       install_requires=['numpy>=1.20', 'pillow'],
-      python_requires='>=3.9',
+      python_requires='>=3.10',
       extras_require={
           'geotiff': ['rasterio>=1.0'],
           'xarray': ['xarray', 'dask[array]'],

--- a/trollimage/tests/test_xrimage.py
+++ b/trollimage/tests/test_xrimage.py
@@ -995,7 +995,7 @@ class TestXRImage:
         np.testing.assert_allclose(enhs['scale'].values, np.array([3.114479], dtype=dtype), atol=1e-6)
         np.testing.assert_allclose(enhs['offset'].values, np.array([-0.00505051], dtype=dtype), atol=1e-8)
         res = np.array([[
-            [-0.005051, 0.037037, 0.079125,  0.121212,  0.1633],
+            [-0.005051, 0.037037, 0.079125, 0.121212, 0.1633],
             [0.205387, 0.247475, 0.289562, 0.33165, 0.373737],
             [0.415825, 0.457913, 0.5, 0.542088, 0.584175],
             [0.6262627, 0.66835034, 0.71043783, 0.7525254, 0.79461294],


### PR DESCRIPTION
Addresses the changes in dask where it is now recommended to not mix Array and Delayed operations as the optimization of Delayed functions will treat each Array input separately and not properly optimize them.

See https://github.com/pytroll/satpy/issues/3152

This PR changes the linear stretch to use xarray's quantile functionality which did not exist when the `XRImage` class was first created. Note that all of the complicated band handling related to quantile calls could be replaced if we remove support for per-band cutoffs.

As far as I could tell there were no tests for single band linear stretch cases so I added some.

 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [x] Tests added (for all bug fixes or enhancements)
 - [x] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
