### PR TITLE
Split wheel building into multiple native runners and drop Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.10", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         experimental: [false]
         include:
           - python-version: "3.13"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,17 +52,11 @@ jobs:
       - run: |
           git fetch --prune --unshallow
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4
         env:
           CIBW_ENABLE: cpython-freethreading
-          CIBW_SKIP: "cp39-* *-manylinux_i686 *-musllinux_i686 *-musllinux_aarch64 *-win32"
+          CIBW_SKIP: "cp39-* cp310-* *-manylinux_i686 *-musllinux_i686 *-musllinux_aarch64 *-win32"
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
 
@@ -80,10 +74,10 @@ jobs:
         with:
           name: sdist
           path: dist
-      - name: Download wheels artifact - win
+      - name: Download wheels artifact
         uses: actions/download-artifact@v5
         with:
-          name: wheels-*
+          pattern: wheels-*
           merge-multiple: true
           path: dist
       - name: Publish package to Test PyPI

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(name="trollimage",
       packages=find_packages(),
       zip_safe=False,
       install_requires=['numpy>=1.25', 'pillow'],
-      python_requires='>=3.10',
+      python_requires='>=3.11',
       extras_require={
           'geotiff': ['rasterio>=1.0'],
           'xarray': ['xarray', 'dask[array]'],


### PR DESCRIPTION
 - [ ] Closes #xxxx (remove if there is no corresponding issue, which should only be the case for minor changes)
 - [ ] Tests added (for all bug fixes or enhancements)
 - [ ] Tests passed (for all non-documentation changes)
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` (remove if you did not edit any Python files)
 - [ ] Fully documented (remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later)
